### PR TITLE
Corrigindo bugs do inspetor

### DIFF
--- a/src/br/univali/ps/ui/inspetor/InspetorDeSimbolos.java
+++ b/src/br/univali/ps/ui/inspetor/InspetorDeSimbolos.java
@@ -605,18 +605,17 @@ public class InspetorDeSimbolos extends JList<ItemDaLista> implements Observador
     }
 
     private boolean adicionaNoMatriz(NoDeclaracaoMatriz noTransferido) {
-        NoDeclaracaoMatriz declaracaoMatriz = ((NoDeclaracaoMatriz) noTransferido);
         int colunas = -1, linhas = -1;
-        if (declaracaoMatriz.getNumeroColunas() != null && declaracaoMatriz.getNumeroLinhas() != null) {
-            colunas = ((NoInteiro) declaracaoMatriz.getNumeroColunas()).getValor();
-            linhas = ((NoInteiro) declaracaoMatriz.getNumeroLinhas()).getValor();
-        } else if (declaracaoMatriz.getInicializacao() != null) {
-            List<List<Object>> valores = ((NoMatriz) declaracaoMatriz.getInicializacao()).getValores();
+        if (noTransferido.getNumeroColunas() != null && noTransferido.getNumeroLinhas() != null) {
+            colunas = ((NoInteiro) noTransferido.getNumeroColunas()).getValor();
+            linhas = ((NoInteiro) noTransferido.getNumeroLinhas()).getValor();
+        } else if (noTransferido.getInicializacao() != null) {
+            List<List<Object>> valores = ((NoMatriz) noTransferido.getInicializacao()).getValores();
             linhas = valores.size();
             colunas = valores.get(0).size();
         }
         if (colunas > 0 && linhas > 0) {
-            model.addElement(new ItemDaListaParaMatriz(linhas, colunas, declaracaoMatriz));
+            model.addElement(new ItemDaListaParaMatriz(linhas, colunas, noTransferido));
             return true;
         }
         return false;

--- a/src/br/univali/ps/ui/inspetor/InspetorDeSimbolos.java
+++ b/src/br/univali/ps/ui/inspetor/InspetorDeSimbolos.java
@@ -8,11 +8,14 @@ import br.univali.portugol.nucleo.asa.NoDeclaracaoMatriz;
 import br.univali.portugol.nucleo.asa.NoDeclaracaoParametro;
 import br.univali.portugol.nucleo.asa.NoDeclaracaoVariavel;
 import br.univali.portugol.nucleo.asa.NoDeclaracaoVetor;
+import br.univali.portugol.nucleo.asa.NoExpressao;
 import br.univali.portugol.nucleo.asa.NoInteiro;
 import br.univali.portugol.nucleo.asa.NoMatriz;
+import br.univali.portugol.nucleo.asa.NoReferenciaVariavel;
 import br.univali.portugol.nucleo.asa.NoVetor;
 import br.univali.portugol.nucleo.asa.Quantificador;
 import br.univali.portugol.nucleo.asa.TipoDado;
+import br.univali.portugol.nucleo.asa.TrechoCodigoFonte;
 import br.univali.portugol.nucleo.execucao.ObservadorExecucao;
 import br.univali.portugol.nucleo.execucao.ResultadoExecucao;
 import br.univali.portugol.nucleo.simbolos.Matriz;
@@ -47,6 +50,8 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -527,18 +532,19 @@ public class InspetorDeSimbolos extends JList<ItemDaLista> implements Observador
             List<NoDeclaracao> nosTransferidos = null;
             try {
                 nosTransferidos = (List<NoDeclaracao>) support.getTransferable().getTransferData(AbaCodigoFonte.NoTransferable.NO_DATA_FLAVOR);
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
-            boolean importou = false;
-            for (NoDeclaracao noTransferido : nosTransferidos) {
-                if (!contemNo(noTransferido)) {
-                    adicionaNo(noTransferido);
-                    importou = true;
+
+                boolean importou = false;
+                for (NoDeclaracao noTransferido : nosTransferidos) {
+                    if (!contemNo(noTransferido)) {
+                        adicionaNo(noTransferido);
+                        importou = true;
+                    }
                 }
+                return importou;
+            } catch (Exception e) {
+                Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, e);
             }
-            return importou;
+            return false;
         }
 
         private boolean importaStringArrastada(TransferHandler.TransferSupport support) {
@@ -589,10 +595,10 @@ public class InspetorDeSimbolos extends JList<ItemDaLista> implements Observador
         return true;
     }
 
-    private boolean adicionaNoVetor(NoDeclaracaoVetor declaracaoVetor) {
+    private boolean adicionaNoVetor(NoDeclaracaoVetor declaracaoVetor) throws ExcecaoVisitaASA {
         int colunas = -1;
         if (declaracaoVetor.getTamanho() != null) {
-            colunas = ((NoInteiro) declaracaoVetor.getTamanho()).getValor();
+            colunas = obtemValorDeExpressaoDoTipoInteiro(declaracaoVetor.getTamanho());
         } else if (declaracaoVetor.getInicializacao() != null) {
             colunas = ((NoVetor) declaracaoVetor.getInicializacao()).getValores().size();
         }
@@ -604,11 +610,42 @@ public class InspetorDeSimbolos extends JList<ItemDaLista> implements Observador
         return false;
     }
 
-    private boolean adicionaNoMatriz(NoDeclaracaoMatriz noTransferido) {
+    private Integer obtemValorDeExpressaoDoTipoInteiro(NoExpressao expressao) throws ExcecaoVisitaASA {
+        if (expressao == null)
+            return null;
+        
+        if (expressao instanceof NoInteiro) {
+            return ((NoInteiro) expressao).getValor();
+        }
+
+        //se a expressão é uma referência para uma variável é necessário encontrar a declaração da variável para obter o seu valor
+        if (expressao instanceof NoReferenciaVariavel) {
+            if (ultimoProgramaCompilado == null) //se não existe um programa então não é possível encontrar um símbolo
+            {
+                return null;
+            }
+
+            NoReferenciaVariavel noReferencia = (NoReferenciaVariavel) expressao;
+            TrechoCodigoFonte trechoFonte = noReferencia.getTrechoCodigoFonte();
+            int linha = trechoFonte.getLinha();
+            int coluna = trechoFonte.getColuna();
+            int tamanho = trechoFonte.getTamanhoTexto();
+            String nomeDoSimbolo = noReferencia.getNome();
+            ProcuradorDeDeclaracao procuradorDeDeclaracao = new ProcuradorDeDeclaracao(nomeDoSimbolo, linha, coluna, tamanho);
+            ultimoProgramaCompilado.getArvoreSintaticaAbstrata().aceitar(procuradorDeDeclaracao);
+            if (procuradorDeDeclaracao.encontrou()) {
+                NoDeclaracao noDeclaracao = procuradorDeDeclaracao.getNoDeclaracao();
+                return obtemValorDeExpressaoDoTipoInteiro(noDeclaracao.getInicializacao()); 
+            }
+        }
+        return null;
+    }
+
+    private boolean adicionaNoMatriz(NoDeclaracaoMatriz noTransferido) throws ExcecaoVisitaASA {
         int colunas = -1, linhas = -1;
         if (noTransferido.getNumeroColunas() != null && noTransferido.getNumeroLinhas() != null) {
-            colunas = ((NoInteiro) noTransferido.getNumeroColunas()).getValor();
-            linhas = ((NoInteiro) noTransferido.getNumeroLinhas()).getValor();
+            colunas = obtemValorDeExpressaoDoTipoInteiro(noTransferido.getNumeroColunas());
+            linhas = obtemValorDeExpressaoDoTipoInteiro(noTransferido.getNumeroLinhas());
         } else if (noTransferido.getInicializacao() != null) {
             List<List<Object>> valores = ((NoMatriz) noTransferido.getInicializacao()).getValores();
             linhas = valores.size();
@@ -638,7 +675,7 @@ public class InspetorDeSimbolos extends JList<ItemDaLista> implements Observador
         return false;
     }
 
-    public void adicionaNo(NoDeclaracao noTransferido) {
+    public void adicionaNo(NoDeclaracao noTransferido) throws ExcecaoVisitaASA {
         boolean simboloInserido = false;
         if (noTransferido instanceof NoDeclaracaoVariavel) {
             simboloInserido = adicionaNoVariavel((NoDeclaracaoVariavel) noTransferido);

--- a/src/br/univali/ps/ui/inspetor/RenderizadorBase.java
+++ b/src/br/univali/ps/ui/inspetor/RenderizadorBase.java
@@ -30,41 +30,35 @@ abstract class RenderizadorBase extends JComponent {
 
     protected ItemDaLista itemDaLista;
 
-    protected static Font FONTE_NORMAL = Font.decode("Tahoma-12");
+    protected static Font FONTE_NORMAL = Font.decode(Font.SANS_SERIF + "-12");
     protected static Font FONTE_DESTAQUE;
     protected static Font FONTE_CABECALHO;
     protected static Font FONTE_CABECALHO_DESTAQUE;
 
     public RenderizadorBase() {
         super();
-        //setTamanhoDaFonte(12f);
-        //setTamanhoDaFonte(18);
+        setTamanhoDaFonte(12f);
     }
-    
-    
+
     static void setTamanhoDaFonte(float tamanho) {
-        if (FONTE_NORMAL != null) {
-            FONTE_NORMAL = FONTE_NORMAL.deriveFont(tamanho);
-            FONTE_DESTAQUE = FONTE_NORMAL.deriveFont(Font.BOLD);
-            
-            if (FONTE_DESTAQUE == null)
-            {
-                FONTE_DESTAQUE = FONTE_NORMAL;
-            }
-            
-            FONTE_CABECALHO = FONTE_NORMAL.deriveFont(12f);
-            
-            if (FONTE_CABECALHO == null)
-            {
-                FONTE_CABECALHO = FONTE_NORMAL;
-            }
-            
-            FONTE_CABECALHO_DESTAQUE = FONTE_CABECALHO.deriveFont(Font.BOLD);
-            
-            if (FONTE_CABECALHO_DESTAQUE == null)
-            {
-                FONTE_CABECALHO_DESTAQUE = FONTE_NORMAL;
-            }
+        assert (FONTE_NORMAL != null);
+        FONTE_NORMAL = FONTE_NORMAL.deriveFont(tamanho);
+        FONTE_DESTAQUE = FONTE_NORMAL.deriveFont(Font.BOLD);
+
+        if (FONTE_DESTAQUE == null) {
+            FONTE_DESTAQUE = FONTE_NORMAL;
+        }
+
+        FONTE_CABECALHO = FONTE_NORMAL.deriveFont(12f);
+
+        if (FONTE_CABECALHO == null) {
+            FONTE_CABECALHO = FONTE_NORMAL;
+        }
+
+        FONTE_CABECALHO_DESTAQUE = FONTE_CABECALHO.deriveFont(Font.BOLD);
+
+        if (FONTE_CABECALHO_DESTAQUE == null) {
+            FONTE_CABECALHO_DESTAQUE = FONTE_NORMAL;
         }
     }
 

--- a/src/br/univali/ps/ui/rstautil/ProcuradorDeDeclaracao.java
+++ b/src/br/univali/ps/ui/rstautil/ProcuradorDeDeclaracao.java
@@ -117,6 +117,10 @@ public class ProcuradorDeDeclaracao extends VisitanteNulo {
     @Override
     public Object visitar(NoDeclaracaoVetor noDeclaracaoVetor) throws ExcecaoVisitaASA {
         verificarNoDeclaracao(noDeclaracaoVetor);
+        if (noDeclaracaoVetor.getTamanho() != null)
+        {
+            noDeclaracaoVetor.getTamanho().aceitar(this);
+        }
         return null;
     }
 


### PR DESCRIPTION
Este pull request corrige os bugs mencionados na issue #82 

@noschang , um dos problemas mencionados na issue estava relacionado com a criação das fontes usadas para desenhar as variáveis no inspetor. O código que criava essas fontes tinha sido comentado no construtor da classe **RenderizadorBase** e estava gerando exceções quando um vetor era arrastado para o inspetor. Eu lembro que tínhamos conversado sobre o problema de criar fontes que poderiam não estar disponíveis em algumas máquinas. Para resolver isso (fontes indisponíveis) eu tentei criar uma fonte padrão, que em teoria sempre estará disponível:
```
protected static Font FONTE_NORMAL = Font.decode(Font.SANS_SERIF + "-12");
```
Esse código cria uma fonte padrão sem serifa. Testei no Windows 10 aqui, **preciso da tua ajuda para testar em outras plataformas**. O teste é simples, basta arrastar um vetor para o inspetor. Se der exceção temos um problema :)

**Outra coisa:** Agora é possível arrastar vetores ou matrizes cujas dimensões sejam referências para variáveis. Isso resolve o problema descrito na issue #82. Masssssss, tem um porém. Não cheguei a testar, mas eu tenho quase certeza que se o código possuir duas variáveis com mesmo nome, mas escopos diferentes, e uma dessas variáveis é usada como dimensão de matriz ou vetor, a solução atual vai utilizar a primeira variável que encontrar na ASA, e que não necessariamente será a variável correta. Eu penso que esses casos são exceções, raramente os alunos vão escrever códigos com estas características. Minha sugestão é verificar se realmente o problema existe e em caso afirmativo abrir uma issue com baixa prioridade.

Se o problema da criação da fonte funcionar em outras plataformas você já pode integrar esse pull request. até+