### PR TITLE
Corrigindo issue #94

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -121,7 +121,7 @@ run.classpath=\
 # Space-separated list of JVM arguments used when running the project.
 # You may also define separate properties like run-sys-prop.name=value instead of -Dname=value.
 # To set system properties for unit tests define test-sys-prop.name=value:
-run.jvmargs=-Xms128m -Xms512m -splash:src/splash.png -Dnetbeans=true
+run.jvmargs=-Xms128m -Xmx512m -splash:src/splash.png -Dnetbeans=true -Dvisualvm.display.name=Portugol-Studio
 run.test.classpath=\
     ${javac.test.classpath}:\
     ${build.test.classes.dir}

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -80,6 +80,7 @@ javac.classpath=\
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
+javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
 javac.source=1.8
@@ -121,7 +122,7 @@ run.classpath=\
 # Space-separated list of JVM arguments used when running the project.
 # You may also define separate properties like run-sys-prop.name=value instead of -Dname=value.
 # To set system properties for unit tests define test-sys-prop.name=value:
-run.jvmargs=-Xms128m -Xmx512m -splash:src/splash.png -Dnetbeans=true -Dvisualvm.display.name=Portugol-Studio
+run.jvmargs=-Xms128m -Xmx512m -splash:src/splash.png -Dnetbeans=true -Xdock:name=Portugol-Studio
 run.test.classpath=\
     ${javac.test.classpath}:\
     ${build.test.classes.dir}

--- a/src/br/univali/ps/atualizador/GerenciadorAtualizacoes.java
+++ b/src/br/univali/ps/atualizador/GerenciadorAtualizacoes.java
@@ -1,6 +1,7 @@
 package br.univali.ps.atualizador;
 
 import br.univali.ps.nucleo.Configuracoes;
+import br.univali.ps.nucleo.NamedThreadFactory;
 import br.univali.ps.nucleo.PortugolStudio;
 import java.io.BufferedReader;
 import java.io.File;
@@ -32,7 +33,7 @@ public final class GerenciadorAtualizacoes
     private static final int HTTP_OK = 200;
 
     private static final Logger LOGGER = Logger.getLogger(GerenciadorAtualizacoes.class.getName());
-    private static final ExecutorService servicoThread = Executors.newSingleThreadExecutor();
+    private static final ExecutorService servicoThread = Executors.newSingleThreadExecutor(new NamedThreadFactory("Portugol Studio (Gerenciador de atualizações)"));
 
     private boolean executando = false;
     private boolean uriModificada = false;

--- a/src/br/univali/ps/nucleo/Mutex.java
+++ b/src/br/univali/ps/nucleo/Mutex.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 public final class Mutex
 {
     private static final Logger LOGGER = Logger.getLogger(Mutex.class.getName());
-    private static final ExecutorService servico = Executors.newCachedThreadPool();
+    private static final ExecutorService servico = Executors.newCachedThreadPool(new NamedThreadFactory("Portugol-Studio (Thread principal)"));
 
     //private static final int PORTA_INICIAL = 49152;
     //private static final int PORTA_FINAL = 65535;

--- a/src/br/univali/ps/nucleo/NamedThreadFactory.java
+++ b/src/br/univali/ps/nucleo/NamedThreadFactory.java
@@ -1,0 +1,64 @@
+
+package br.univali.ps.nucleo;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ *
+ * @author Luiz Fernando Noschang
+ * @since 03/01/2016
+ */
+public final class NamedThreadFactory implements ThreadFactory
+{
+    private static Integer count = -1;
+    
+    private final String nameFormat;
+    private final Integer priority;
+
+    public NamedThreadFactory()
+    {
+        this.nameFormat = "Thread";
+        this.priority = Thread.NORM_PRIORITY;
+    }
+    
+    public NamedThreadFactory(String nameFormat)
+    {
+        this.nameFormat = nameFormat;
+        this.priority = Thread.NORM_PRIORITY;
+    }
+    
+    public NamedThreadFactory(Integer priority)
+    {
+        this.nameFormat = "Thread";
+        this.priority = priority;
+    }
+
+    public NamedThreadFactory(String nameFormat, Integer priority)
+    {
+        this.nameFormat = nameFormat;
+        this.priority = priority;
+    }    
+
+    @Override
+    public Thread newThread(Runnable runnable)
+    {
+        count++;
+        String name;
+                
+        Thread thread = new Thread(runnable);
+
+        if (nameFormat.contains("%d"))
+        {
+            name = String.format(nameFormat, count);
+        }
+        else
+        {
+            name = nameFormat;
+        }
+        
+        thread.setName(name);
+        thread.setPriority(priority);
+        
+        return thread;
+    }    
+}

--- a/src/br/univali/ps/nucleo/NamedThreadFactory.java
+++ b/src/br/univali/ps/nucleo/NamedThreadFactory.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ThreadFactory;
  */
 public final class NamedThreadFactory implements ThreadFactory
 {
-    private static Integer count = -1;
+    private Integer count = -1;
     
     private final String nameFormat;
     private final Integer priority;

--- a/src/br/univali/ps/nucleo/PortugolStudio.java
+++ b/src/br/univali/ps/nucleo/PortugolStudio.java
@@ -58,7 +58,8 @@ import javax.swing.UIManager;
  * @author Luiz Fernando Noschang
  * @since 22/08/2011
  */
-public final class PortugolStudio {
+public final class PortugolStudio
+{
 
     private static final Logger LOGGER = Logger.getLogger(PortugolStudio.class.getName());
     private static PortugolStudio instancia = null;
@@ -84,24 +85,31 @@ public final class PortugolStudio {
     private TratadorExcecoes tratadorExcecoes = null;
     private GerenciadorAtualizacoes gerenciadorAtualizacoes = null;
 
-    private PortugolStudio() {
+    private PortugolStudio()
+    {
 
     }
 
-    public static PortugolStudio getInstancia() {
-        if (instancia == null) {
+    public static PortugolStudio getInstancia()
+    {
+        if (instancia == null)
+        {
             instancia = new PortugolStudio();
         }
 
         return instancia;
     }
 
-    public void iniciar(final String[] parametros) {
-        try {
+    public void iniciar(final String[] parametros)
+    {
+        try
+        {
             exibirParametros(parametros);
 
-            if (Mutex.existeUmaInstanciaExecutando()) {
-                try {
+            if (Mutex.existeUmaInstanciaExecutando())
+            {
+                try
+                {
                     Mutex.InstanciaPortugolStudio studio = Mutex.conectarInstanciaPortugolStudio();
                     processarParametroArquivosIniciais(parametros);
 
@@ -109,22 +117,30 @@ public final class PortugolStudio {
                     studio.desconectar();
 
                     finalizar(0);
-                } catch (Mutex.ErroConexaoInstancia erro) {
+                }
+                catch (Mutex.ErroConexaoInstancia erro)
+                {
                     // Se o arquivo de Mutex existe, mas não foi possível abrir a conexão para a instância,
                     // então provavelmente o aplicativo foi fechado de forma inesperada deixando o arquivo pra trás.
                     // Neste caso, apagamos o arquivo e iniciamos uma nova instãncia
                     iniciarNovaInstancia(parametros);
                 }
-            } else {
+            }
+            else
+            {
                 iniciarNovaInstancia(parametros);
             }
-        } catch (Mutex.ErroCriacaoMutex erro) {
+        }
+        catch (Mutex.ErroCriacaoMutex erro)
+        {
             getTratadorExcecoes().exibirExcecao(erro);
         }
     }
 
-    private void iniciarNovaInstancia(String[] parametros) throws Mutex.ErroCriacaoMutex {
-        if (versaoJavaCorreta()) {
+    private void iniciarNovaInstancia(String[] parametros) throws Mutex.ErroCriacaoMutex
+    {
+        if (versaoJavaCorreta())
+        {
             Mutex.criar();
 
             String dica = obterProximaDica();
@@ -164,9 +180,12 @@ public final class PortugolStudio {
             //AbaCodigoFonte.inicializarPool();
             Splash.definirProgresso(100, "step9.png");
 
-            try {
+            try
+            {
                 exibirTelaPrincipal();
-            } catch (ExcecaoAplicacao excecaoAplicacao) {
+            }
+            catch (ExcecaoAplicacao excecaoAplicacao)
+            {
                 getTratadorExcecoes().exibirExcecao(excecaoAplicacao);
                 finalizar(1);
             }
@@ -175,26 +194,32 @@ public final class PortugolStudio {
         }
     }
 
-    public void finalizar(int codigo) {
+    public void finalizar(int codigo)
+    {
         Mutex.destruir();
         Configuracoes.getInstancia().salvar();
         System.exit(codigo);
     }
 
-    public String obterProximaDica() {
-        if (dicas.isEmpty()) {
+    public String obterProximaDica()
+    {
+        if (dicas.isEmpty())
+        {
             carregarDicas();
             carregarDicasExibidas();
         }
 
-        if (dicasExibidas.size() == dicas.size()) {
+        if (dicasExibidas.size() == dicas.size())
+        {
             dicasExibidas.clear();
         }
 
-        if (!dicas.isEmpty()) {
+        if (!dicas.isEmpty())
+        {
             int indice = random.nextInt(dicas.size());
 
-            while (dicasExibidas.contains(indice)) {
+            while (dicasExibidas.contains(indice))
+            {
                 indice = (indice + 1) % dicas.size();
             }
 
@@ -207,85 +232,116 @@ public final class PortugolStudio {
         return null;
     }
 
-    private void carregarDicas() {
+    private void carregarDicas()
+    {
         String linha;
 
-        try (BufferedReader leitor = new BufferedReader(new InputStreamReader(getClass().getClassLoader().getResourceAsStream("dicas.txt"), "UTF-8"))) {
-            while ((linha = leitor.readLine()) != null) {
-                if (linha.trim().length() != 0 && !linha.startsWith("#")) {
+        try (BufferedReader leitor = new BufferedReader(new InputStreamReader(getClass().getClassLoader().getResourceAsStream("dicas.txt"), "UTF-8")))
+        {
+            while ((linha = leitor.readLine()) != null)
+            {
+                if (linha.trim().length() != 0 && !linha.startsWith("#"))
+                {
                     dicas.add(linha);
                 }
             }
-        } catch (IOException excecao) {
+        }
+        catch (IOException excecao)
+        {
             LOGGER.log(Level.SEVERE, "Erro ao carregar as dicas da Splash Screen", excecao);
         }
     }
 
-    private void carregarDicasExibidas() {
+    private void carregarDicasExibidas()
+    {
         File arquivoDicas = Configuracoes.getInstancia().getCaminhoArquivoDicas();
         String linha;
 
-        if (arquivoDicas.exists()) {
-            try (BufferedReader leitor = new BufferedReader(new FileReader(arquivoDicas))) {
-                while ((linha = leitor.readLine()) != null) {
-                    if (linha.trim().length() != 0 && !linha.startsWith("#")) {
+        if (arquivoDicas.exists())
+        {
+            try (BufferedReader leitor = new BufferedReader(new FileReader(arquivoDicas)))
+            {
+                while ((linha = leitor.readLine()) != null)
+                {
+                    if (linha.trim().length() != 0 && !linha.startsWith("#"))
+                    {
                         dicasExibidas.add(Integer.parseInt(linha));
                     }
                 }
-            } catch (IOException excecao) {
+            }
+            catch (IOException excecao)
+            {
                 LOGGER.log(Level.SEVERE, "Erro ao carregar as dicas já exibidas", excecao);
             }
         }
     }
 
-    private void salvarDicasExibidas() {
-        if (!dicasExibidas.isEmpty()) {
+    private void salvarDicasExibidas()
+    {
+        if (!dicasExibidas.isEmpty())
+        {
             File arquivoDicas = Configuracoes.getInstancia().getCaminhoArquivoDicas();
 
-            try (BufferedWriter escritor = new BufferedWriter(new FileWriter(arquivoDicas))) {
-                for (Integer indice : dicasExibidas) {
+            try (BufferedWriter escritor = new BufferedWriter(new FileWriter(arquivoDicas)))
+            {
+                for (Integer indice : dicasExibidas)
+                {
                     escritor.write(indice.toString());
                     escritor.newLine();
                 }
-            } catch (IOException excecao) {
+            }
+            catch (IOException excecao)
+            {
                 LOGGER.log(Level.SEVERE, "Erro ao salvar as dicas já exibidas", excecao);
             }
         }
     }
 
-    private boolean versaoJavaCorreta() {
-        try {
+    private boolean versaoJavaCorreta()
+    {
+        try
+        {
             String property = System.getProperty("java.specification.version");
 
-            if (Double.valueOf(property) < 1.7) {
+            if (Double.valueOf(property) < 1.7)
+            {
                 JOptionPane.showMessageDialog(null, "Para executar o Portugol Studio é preciso utilizar o Java 1.7 ou superior.", "Portugol Studio", JOptionPane.ERROR_MESSAGE);
                 return false;
             }
 
             return true;
-        } catch (HeadlessException | NumberFormatException excecao) {
+        }
+        catch (HeadlessException | NumberFormatException excecao)
+        {
             JOptionPane.showMessageDialog(null, "Não foi possível determinar a versão do Java. O Portugol Studio será encerrado!", "Portugol Studio", JOptionPane.ERROR_MESSAGE);
             return false;
         }
     }
 
-    private void inicializarMecanismoLog() {
+    private void inicializarMecanismoLog()
+    {
         final InputStream inputStream = TelaPrincipal.class.getResourceAsStream("/logging.properties");
 
-        try {
+        try
+        {
             LogManager.getLogManager().readConfiguration(inputStream);
-        } catch (final IOException excecao) {
+        }
+        catch (final IOException excecao)
+        {
             Logger.getAnonymousLogger().severe("Não foi possível localizar o arquivo de configuração de log 'logging.properties'");
             Logger.getAnonymousLogger().log(Level.SEVERE, excecao.getMessage(), excecao);
         }
     }
 
-    private void instalarDetectorExcecoesNaoTratadas() {
+    private void instalarDetectorExcecoesNaoTratadas()
+    {
         Thread.setDefaultUncaughtExceptionHandler(getTratadorExcecoes());
     }
 
-    private void processarParametrosLinhaComando(final String[] parametros) {
-        if (parametros != null) {
+    private void processarParametrosLinhaComando(final String[] parametros)
+    {
+        if (parametros != null)
+        {
             processarParametroModoDepuracao(parametros);
             processarParametroArquivosIniciais(parametros);
             processarParametroDiretoriosPlugins(parametros);
@@ -293,47 +349,64 @@ public final class PortugolStudio {
         }
     }
 
-    private void processarParametroUriAtualizacao(final String[] parametros) {
-        if (parametroExiste("-atualizacao=*", parametros)) {
+    private void processarParametroUriAtualizacao(final String[] parametros)
+    {
+        if (parametroExiste("-atualizacao=*", parametros))
+        {
             String parametro = obterParametro("-atualizacao=*", parametros);
 
             String uri = parametro.split("=")[1].trim();
 
-            if (uri.length() > 0) {
-                try {
+            if (uri.length() > 0)
+            {
+                try
+                {
                     uriAtualizacao = new URI(uri).toString();
-                } catch (URISyntaxException excecao) {
+                }
+                catch (URISyntaxException excecao)
+                {
 
                 }
             }
         }
     }
 
-    private void processarParametroDiretoriosPlugins(final String[] parametros) {
-        if (parametroExiste("-plugins=*", parametros)) {
+    private void processarParametroDiretoriosPlugins(final String[] parametros)
+    {
+        if (parametroExiste("-plugins=*", parametros))
+        {
             String parametro = obterParametro("-plugins=*", parametros);
 
             String descDiretorios = parametro.split("=")[1];
             String[] diretorios = descDiretorios.split(",");
 
-            if (diretorios != null && diretorios.length > 0) {
-                for (String diretorio : diretorios) {
+            if (diretorios != null && diretorios.length > 0)
+            {
+                for (String diretorio : diretorios)
+                {
                     diretoriosPluginsInformadosPorParametro.add(new File(diretorio));
                 }
             }
         }
     }
 
-    private void processarParametroModoDepuracao(final String[] parametros) {
+    private void processarParametroModoDepuracao(final String[] parametros)
+    {
         setDepurando(parametroExiste("-debug", parametros));
     }
 
-    private boolean parametroExiste(String nome, String[] parametros) {
-        for (String parametro : parametros) {
-            if (nome.endsWith("*") && parametro.startsWith(nome.replace("*", ""))) {
+    private boolean parametroExiste(String nome, String[] parametros)
+    {
+        for (String parametro : parametros)
+        {
+            if (nome.endsWith("*") && parametro.startsWith(nome.replace("*", "")))
+            {
                 return true;
-            } else {
-                if (!nome.endsWith("*") && parametro.equals(nome)) {
+            }
+            else
+            {
+                if (!nome.endsWith("*") && parametro.equals(nome))
+                {
                     return true;
                 }
             }
@@ -342,33 +415,44 @@ public final class PortugolStudio {
         return false;
     }
 
-    private void processarParametroArquivosIniciais(String[] argumentos) {
-        if (argumentos != null && argumentos.length > 0) {
-            for (String argumento : argumentos) {
+    private void processarParametroArquivosIniciais(String[] argumentos)
+    {
+        if (argumentos != null && argumentos.length > 0)
+        {
+            for (String argumento : argumentos)
+            {
                 File arquivo = new File(argumento);
 
-                if (arquivo.exists() && arquivo.isFile() && arquivo.canRead()) {
+                if (arquivo.exists() && arquivo.isFile() && arquivo.canRead())
+                {
                     arquivosIniciais.add(arquivo);
                 }
             }
         }
     }
 
-    private void instalarDetectorVialacoesNaThreadSwing() {
+    private void instalarDetectorVialacoesNaThreadSwing()
+    {
         RepaintManager.setCurrentManager(new DetectorViolacoesThreadSwing());
     }
 
-    private void definirLookAndFeel() {
+    private void definirLookAndFeel()
+    {
 
-        SwingUtilities.invokeLater(new Runnable() {
+        SwingUtilities.invokeLater(new Runnable()
+        {
 
             @Override
-            public void run() {
-                try {
+            public void run()
+            {
+                try
+                {
                     FabricaDeFileChooser.inicializar();//cria as instâncias de JFileChooser com o look and feel do sistema antes que o WebLaf seja instalado
                     //UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
                     WeblafUtils.instalaWeblaf();
-                } catch (Exception e) {
+                }
+                catch (Exception e)
+                {
                     LOGGER.log(Level.SEVERE, e.getMessage(), e);
                 }
 
@@ -377,11 +461,13 @@ public final class PortugolStudio {
 
     }
 
-    private void registrarFontes() {
+    private void registrarFontes()
+    {
         final String path = "br/univali/ps/ui/fontes/";
 
         final String[] fontes
-                = {
+                =
+                {
                     "OpenSans-Bold.ttf",
                     "OpenSans-Italic.ttf",
                     "OpenSans-Regular.ttf",
@@ -393,87 +479,94 @@ public final class PortugolStudio {
                     "tahomabd.ttf"
                 };
 
-        for (String nome : fontes) {
-            try {
+        for (String nome : fontes)
+        {
+            try
+            {
                 Font fonte = Font.createFont(Font.TRUETYPE_FONT, Thread.currentThread().getContextClassLoader().getResourceAsStream(path + nome));
                 GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(fonte);
-            } catch (FontFormatException | IOException excecao) {
+            }
+            catch (FontFormatException | IOException excecao)
+            {
                 final String mensagem = String.format("Não foi possível registrar a fonte '%s' no ambiente", nome);
 
                 LOGGER.log(Level.INFO, mensagem, excecao);
             }
-
-            /* 
-             * Se estiver rodando o projeto dentro do NetBeans com o JDK 7, é possível que JavaFX não seja encontrado
-             * no classpath e um ClassNotFoundException seja gerado.
-             *
-             * Isto é um bug e ocorre quando o NetBeans é executado com o JDK 8. Para executar corretamente, deve-se
-             * alterar o arquivo de configurações do NetBeans (netbeans.conf) para executar com o JDK 7.
-             * 
-             */
-            javafx.scene.text.Font.loadFont(Thread.currentThread().getContextClassLoader().getResourceAsStream(path + nome), 12);
         }
     }
 
-    private void definirFontePadraoInterface() {
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    Enumeration keys = UIManager.getDefaults().keys();
+    private void definirFontePadraoInterface()
+    {
+        try
+        {
+            SwingUtilities.invokeAndWait(() ->
+            {
+                Enumeration keys = UIManager.getDefaults().keys();
 
-                    while (keys.hasMoreElements()) {
-                        Object key = keys.nextElement();
-                        Object value = UIManager.get(key);
+                while (keys.hasMoreElements())
+                {
+                    Object key = keys.nextElement();
+                    Object value = UIManager.get(key);
 
-                        if (value instanceof javax.swing.plaf.FontUIResource) {
-                            /*
-                             * Não está funcionando. O swing altera a fonte padrão para a maioria dos componentes,
-                             * mas não todos. Além disso, o tamanho da fonte da árvore estrutural para de funcionar
-                             *
-                             */
-                            //UIManager.put(key, new Font("Tahoma", Font.PLAIN, 11));                            
-                        }
+                    if (value instanceof javax.swing.plaf.FontUIResource)
+                    {
+                        /*
+                         * Não está funcionando. O swing altera a fonte padrão para a maioria dos componentes,
+                         * mas não todos. Além disso, o tamanho da fonte da árvore estrutural para de funcionar
+                         *
+                         */
+                        //UIManager.put(key, new Font("Tahoma", Font.PLAIN, 11));
                     }
                 }
             });
-        } catch (InterruptedException | InvocationTargetException excecao) {
+        }
+        catch (InterruptedException | InvocationTargetException excecao)
+        {
             LOGGER.log(Level.INFO, "Não foi possível definir uma fonte padrão na interface do usuário", excecao);
         }
     }
 
-    private void carregarPlugins() {
+    private void carregarPlugins()
+    {
         GerenciadorPlugins gerenciadorPlugins = GerenciadorPlugins.getInstance();
         Configuracoes configuracoes = Configuracoes.getInstancia();
 
-        if (configuracoes.getDiretorioPlugins() != null) {
+        if (configuracoes.getDiretorioPlugins() != null)
+        {
             File diretorioPlugins = configuracoes.getDiretorioPlugins();
 
             LOGGER.log(Level.INFO, "Inicializando plugins em: {0}", diretorioPlugins.getAbsolutePath());
 
-            if (diretorioPlugins.exists()) {
-                for (File pastaPlugin : listarPastasPlugins(diretorioPlugins)) {
+            if (diretorioPlugins.exists())
+            {
+                for (File pastaPlugin : listarPastasPlugins(diretorioPlugins))
+                {
                     LOGGER.log(Level.INFO, "Inicializando plugin {0}", pastaPlugin.getAbsolutePath());
                     gerenciadorPlugins.incluirDiretorioPlugin(pastaPlugin);
                 }
             }
         }
 
-        for (File diretorio : diretoriosPluginsInformadosPorParametro) {
+        for (File diretorio : diretoriosPluginsInformadosPorParametro)
+        {
             gerenciadorPlugins.incluirDiretorioPlugin(diretorio);
         }
 
         gerenciadorPlugins.carregarPlugins();
     }
 
-    private void carregarBibliotecas() {
+    private void carregarBibliotecas()
+    {
         // Implementar depois
     }
 
-    private List<File> listarPastasPlugins(File diretorioPlugins) {
-        File[] diretorios = diretorioPlugins.listFiles(new FileFilter() {
+    private List<File> listarPastasPlugins(File diretorioPlugins)
+    {
+        File[] diretorios = diretorioPlugins.listFiles(new FileFilter()
+        {
             @Override
-            public boolean accept(File pathname) {
+            public boolean accept(File pathname)
+            {
                 return pathname.isDirectory();
             }
         });
@@ -481,82 +574,106 @@ public final class PortugolStudio {
         return Arrays.asList(diretorios);
     }
 
-    private void exibirTelaPrincipal() throws ExcecaoAplicacao {
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
+    private void exibirTelaPrincipal() throws ExcecaoAplicacao
+    {
+        try
+        {
+            SwingUtilities.invokeAndWait(new Runnable()
+            {
                 @Override
-                public void run() {
+                public void run()
+                {
                     getTelaPrincipal().setVisible(true);
                 }
             });
-        } catch (InterruptedException | InvocationTargetException ex) {
+        }
+        catch (InterruptedException | InvocationTargetException ex)
+        {
             throw new ExcecaoAplicacao("Não foi possível iniciar o Portugol Studio", ex, ExcecaoAplicacao.Tipo.ERRO);
         }
     }
 
-    public String getVersao() {
-        if (versao == null) {
+    public String getVersao()
+    {
+        if (versao == null)
+        {
             versao = carregarVersao();
         }
 
         return versao;
     }
 
-    private String carregarVersao() {
-        try {
+    private String carregarVersao()
+    {
+        try
+        {
             Properties propriedades = new Properties();
             propriedades.load(getClass().getClassLoader().getResourceAsStream("versao.properties"));
 
             return propriedades.getProperty("portugol.studio.versao");
-        } catch (IOException excecao) {
+        }
+        catch (IOException excecao)
+        {
             LOGGER.log(Level.SEVERE, "Erro ao carregar o arquivo de versão", excecao);
         }
 
         return "Indefinida";
     }
 
-    public TelaPrincipal getTelaPrincipal() {
-        if (telaPrincipal == null) {
+    public TelaPrincipal getTelaPrincipal()
+    {
+        if (telaPrincipal == null)
+        {
             telaPrincipal = new TelaPrincipal();
             telaPrincipal.setArquivosIniciais(arquivosIniciais);
         }
         return telaPrincipal;
     }
 
-    public boolean isDepurando() {
+    public boolean isDepurando()
+    {
         return depurando;
     }
 
-    public void setDepurando(boolean depurando) {
+    public void setDepurando(boolean depurando)
+    {
         this.depurando = depurando;
     }
 
-    public TratadorExcecoes getTratadorExcecoes() {
-        if (tratadorExcecoes == null) {
+    public TratadorExcecoes getTratadorExcecoes()
+    {
+        if (tratadorExcecoes == null)
+        {
             tratadorExcecoes = new TratadorExcecoes();
         }
 
         return tratadorExcecoes;
     }
 
-    public GerenciadorTemas getGerenciadorTemas() {
-        if (gerenciadorTemas == null) {
+    public GerenciadorTemas getGerenciadorTemas()
+    {
+        if (gerenciadorTemas == null)
+        {
             gerenciadorTemas = new GerenciadorTemas();
         }
 
         return gerenciadorTemas;
     }
 
-    public GerenciadorAtualizacoes getGerenciadorAtualizacoes() {
-        if (gerenciadorAtualizacoes == null) {
+    public GerenciadorAtualizacoes getGerenciadorAtualizacoes()
+    {
+        if (gerenciadorAtualizacoes == null)
+        {
             gerenciadorAtualizacoes = new GerenciadorAtualizacoes();
         }
 
         return gerenciadorAtualizacoes;
     }
 
-    public TelaSobre getTelaSobre() {
-        if (telaSobre == null) {
+    public TelaSobre getTelaSobre()
+    {
+        if (telaSobre == null)
+        {
             telaSobre = new TelaSobre();
         }
 
@@ -565,8 +682,10 @@ public final class PortugolStudio {
         return telaSobre;
     }
 
-    public TelaInformacoesPlugin getTelaInformacoesPlugin() {
-        if (telaInformacoesPlugin == null) {
+    public TelaInformacoesPlugin getTelaInformacoesPlugin()
+    {
+        if (telaInformacoesPlugin == null)
+        {
             telaInformacoesPlugin = new TelaInformacoesPlugin();
         }
 
@@ -575,8 +694,10 @@ public final class PortugolStudio {
         return telaInformacoesPlugin;
     }
 
-    public TelaErrosPluginsBibliotecas getTelaErrosPluginsBibliotecas() {
-        if (telaErrosPluginsBibliotecas == null) {
+    public TelaErrosPluginsBibliotecas getTelaErrosPluginsBibliotecas()
+    {
+        if (telaErrosPluginsBibliotecas == null)
+        {
             telaErrosPluginsBibliotecas = new TelaErrosPluginsBibliotecas();
         }
 
@@ -585,8 +706,10 @@ public final class PortugolStudio {
         return telaErrosPluginsBibliotecas;
     }
 
-    public TelaLicencas getTelaLicencas() {
-        if (telaLicencas == null) {
+    public TelaLicencas getTelaLicencas()
+    {
+        if (telaLicencas == null)
+        {
             telaLicencas = new TelaLicencas();
         }
 
@@ -595,20 +718,28 @@ public final class PortugolStudio {
         return telaLicencas;
     }
 
-    public String getUriAtualizacao() {
-        if (uriAtualizacao.endsWith("/")) {
+    public String getUriAtualizacao()
+    {
+        if (uriAtualizacao.endsWith("/"))
+        {
             uriAtualizacao = uriAtualizacao.substring(0, uriAtualizacao.length() - 1);
         }
 
         return uriAtualizacao;
     }
 
-    private String obterParametro(String nome, String[] parametros) {
-        for (String parametro : parametros) {
-            if (nome.endsWith("*") && parametro.startsWith(nome.replace("*", ""))) {
+    private String obterParametro(String nome, String[] parametros)
+    {
+        for (String parametro : parametros)
+        {
+            if (nome.endsWith("*") && parametro.startsWith(nome.replace("*", "")))
+            {
                 return parametro;
-            } else {
-                if (!nome.endsWith("*") && parametro.equals(nome)) {
+            }
+            else
+            {
+                if (!nome.endsWith("*") && parametro.equals(nome))
+                {
                     return parametro;
                 }
             }
@@ -617,8 +748,10 @@ public final class PortugolStudio {
         return null;
     }
 
-    private void exibirParametros(String[] parametros) {
-        for (String parametro : parametros) {
+    private void exibirParametros(String[] parametros)
+    {
+        for (String parametro : parametros)
+        {
             LOGGER.log(Level.INFO, "Parametro: {0}", parametro);
         }
     }

--- a/src/br/univali/ps/ui/TelaPrincipal.java
+++ b/src/br/univali/ps/ui/TelaPrincipal.java
@@ -16,6 +16,7 @@ import br.univali.ps.ui.util.IconFactory;
 import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -25,70 +26,104 @@ import javax.imageio.ImageIO;
 import javax.swing.*;
 import org.apache.commons.io.FileUtils;
 
-public final class TelaPrincipal extends JFrame {
+public final class TelaPrincipal extends JFrame
+{
 
     private static final Logger LOGGER = Logger.getLogger(TelaPrincipal.class.getName());
 
     private boolean abrindo = true;
     private List<File> arquivosIniciais;
 
-    public static void main(final String argumentos[]) {
+    public static void main(final String argumentos[])
+    {
+        System.setProperty("apple.laf.useScreenMenuBar", "true");
+        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Portugol Studio");
+
+        try
+        {
+            SwingUtilities.invokeAndWait(() ->
+            {
+                Thread.currentThread().setName("Portugol-Studio (Swing)");
+            });
+
+        }
+        catch (InterruptedException | InvocationTargetException ex)
+        {
+            Logger.getLogger(TelaPrincipal.class.getName()).log(Level.SEVERE, null, ex);
+        }
+
         PortugolStudio.getInstancia().iniciar(argumentos);
-         
     }
 
-    public TelaPrincipal() {
+    public TelaPrincipal()
+    {
         initComponents();
         configurarJanela();
         criaAbas();
         instalarObservadores();
-        
+
     }
 
-    public void setArquivosIniciais(List<File> arquivos) {
+    public void setArquivosIniciais(List<File> arquivos)
+    {
         this.arquivosIniciais = arquivos;
     }
 
-    private void criaAbas() {
+    private void criaAbas()
+    {
         painelTabuladoPrincipal.setAbaInicial(new AbaInicial(this));
-        
+
     }
 
-    private void configurarJanela() {
+    private void configurarJanela()
+    {
         setLocationRelativeTo(null);
         setExtendedState(JFrame.MAXIMIZED_BOTH);
 
-        try {
+        try
+        {
             this.setIconImage(ImageIO.read(ClassLoader.getSystemResourceAsStream(IconFactory.CAMINHO_ICONES_GRANDES + "/light-bulb.png")));
-        } catch (IOException ioe) {
+        }
+        catch (IOException ioe)
+        {
         }
     }
 
-    private void instalarObservadores() {
+    private void instalarObservadores()
+    {
         instalarObservadorJanela();
     }
 
-    private void instalarObservadorJanela() {
-        addWindowListener(new WindowAdapter() {
+    private void instalarObservadorJanela()
+    {
+        addWindowListener(new WindowAdapter()
+        {
             @Override
-            public void windowClosing(WindowEvent e) {
+            public void windowClosing(WindowEvent e)
+            {
                 fecharAplicativo();
             }
         });
 
-        addComponentListener(new ComponentAdapter() {
+        addComponentListener(new ComponentAdapter()
+        {
             @Override
-            public void componentShown(ComponentEvent e) {
-                if (abrindo) {
+            public void componentShown(ComponentEvent e)
+            {
+                if (abrindo)
+                {
                     abrindo = false;
 
                     // Por enquanto o André pediu para desativar esta verificação, ela só estará disponível 
                     // no final do ano
                     //verificarAtualizacaoCritica();
-                    if (Configuracoes.getInstancia().isExibirTutorialUso()) {
+                    if (Configuracoes.getInstancia().isExibirTutorialUso())
+                    {
                         //TODO: criar e executar tutorial de uso antes de iniciar o Portugol
                         dispararProcessosAbertura();
-                    } else {
+                    }
+                    else
+                    {
                         dispararProcessosAbertura();
                     }
                 }
@@ -96,10 +131,12 @@ public final class TelaPrincipal extends JFrame {
         });
     }
 
-    private void verificarAtualizacaoCritica() {
+    private void verificarAtualizacaoCritica()
+    {
         File diretorioJava = new File(Configuracoes.getInstancia().getDiretorioInstalacao(), "java");
 
-        if (!diretorioJava.exists() && Configuracoes.rodandoNoWindows() && !Configuracoes.rodandoNoNetbeans()) {
+        if (!diretorioJava.exists() && Configuracoes.rodandoNoWindows() && !Configuracoes.rodandoNoNetbeans())
+        {
             String mensagem = "Caro usuário, foi lançada uma atualização crítica para o Portugol Studio que não pode ser\n"
                     + "instalada através do sistema de atualização automática.\n\n"
                     + "Você pode continuar utilizando o Portugol Studio normalmente, mas é altamente recomendável que\n"
@@ -110,17 +147,22 @@ public final class TelaPrincipal extends JFrame {
 
             int opcao = JOptionPane.showConfirmDialog(TelaPrincipal.this, mensagem, "Portugol Studio", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
 
-            if (opcao == JOptionPane.YES_OPTION) {
-                try {
+            if (opcao == JOptionPane.YES_OPTION)
+            {
+                try
+                {
                     java.awt.Desktop.getDesktop().browse(java.net.URI.create("http://sourceforge.net/projects/portugolstudio"));
-                } catch (IOException ex) {
+                }
+                catch (IOException ex)
+                {
                     JOptionPane.showMessageDialog(TelaPrincipal.this, "Não foi possível abrir o seu navegador de Internet!\nPara baixar a versão mais recente do Portugol Studio, acesse manualmente o endereço:\n\nhttp://sourceforge.net/projects/portugolstudio", "Portugol Studio", JOptionPane.INFORMATION_MESSAGE);
                 }
             }
         }
     }
 
-    private void dispararProcessosAbertura() {
+    private void dispararProcessosAbertura()
+    {
         abrirArquivosCodigoFonte(arquivosIniciais);
 
         exibirErrosPluginsBibliotecas();
@@ -129,21 +171,26 @@ public final class TelaPrincipal extends JFrame {
         baixarNovasAtualizacoes();
     }
 
-    private void exibirErrosPluginsBibliotecas() {
+    private void exibirErrosPluginsBibliotecas()
+    {
         boolean errosPlugins = GerenciadorPlugins.getInstance().getResultadoCarregamento().contemErros();
         boolean errosBibliotecas = false;
 
-        if (errosPlugins || errosBibliotecas) {
+        if (errosPlugins || errosBibliotecas)
+        {
             TelaErrosPluginsBibliotecas telaErrosPluginsBibliotecas = PortugolStudio.getInstancia().getTelaErrosPluginsBibliotecas();
             telaErrosPluginsBibliotecas.setVisible(true);
         }
     }
 
-    private void exibirLogAtualizacoes() {
+    private void exibirLogAtualizacoes()
+    {
         File logAtualizacoes = Configuracoes.getInstancia().getCaminhoLogAtualizacoes();
 
-        if (logAtualizacoes.exists()) {
-            try {
+        if (logAtualizacoes.exists())
+        {
+            try
+            {
                 String atualizacoes = FileHandle.open(logAtualizacoes);
                 TelaLogAtualizacoes telaLogAtualizacoes = new TelaLogAtualizacoes();
 
@@ -151,17 +198,22 @@ public final class TelaPrincipal extends JFrame {
                 telaLogAtualizacoes.setVisible(true);
 
                 FileUtils.deleteQuietly(logAtualizacoes);
-            } catch (Exception excecao) {
+            }
+            catch (Exception excecao)
+            {
                 LOGGER.log(Level.SEVERE, "Erro ao carregar o log de atualizações", excecao);
             }
         }
     }
 
-    private void baixarNovasAtualizacoes() {
+    private void baixarNovasAtualizacoes()
+    {
         GerenciadorAtualizacoes gerenciadorAtualizacoes = PortugolStudio.getInstancia().getGerenciadorAtualizacoes();
-        gerenciadorAtualizacoes.setObservadorAtualizacao(new ObservadorAtualizacao() {
+        gerenciadorAtualizacoes.setObservadorAtualizacao(new ObservadorAtualizacao()
+        {
             @Override
-            public void atualizacaoConcluida() {
+            public void atualizacaoConcluida()
+            {
                 //BotoesControleAba cabecalho = (BotoesControleAba) getPainelTabulado().getAbaInicial().getCabecalho();
                 FabricaDicasInterface.mostrarNotificacao("Foram encontradas novas atualizações. Elas serão instaladas na próxima vez em que o Portugol Studio for iniciado");
             }
@@ -170,34 +222,46 @@ public final class TelaPrincipal extends JFrame {
         gerenciadorAtualizacoes.baixarAtualizacoes();
     }
 
-    public void criarNovoCodigoFonte() {
+    public void criarNovoCodigoFonte()
+    {
         final AbaCodigoFonte abaCodigoFonte = AbaCodigoFonte.novaAba();
         painelTabuladoPrincipal.add(abaCodigoFonte);
         revalidate();
     }
 
-    public void abrirArquivosCodigoFonte(final List<File> arquivos) {
-        if (arquivos != null && !arquivos.isEmpty()) {
+    public void abrirArquivosCodigoFonte(final List<File> arquivos)
+    {
+        if (arquivos != null && !arquivos.isEmpty())
+        {
             focarJanela();
 
-            SwingUtilities.invokeLater(new Runnable() {
+            SwingUtilities.invokeLater(new Runnable()
+            {
                 @Override
-                public void run() {
+                public void run()
+                {
                     TelaPrincipal.this.setEnabled(false);
 
-                    for (File arquivo : arquivos) {
-                        if (arquivoJaEstaAberto(arquivo)) {
+                    for (File arquivo : arquivos)
+                    {
+                        if (arquivoJaEstaAberto(arquivo))
+                        {
                             AbaCodigoFonte aba = obterAbaArquivo(arquivo);
                             aba.selecionar();
-                        } else {
-                            try {
+                        }
+                        else
+                        {
+                            try
+                            {
                                 final String conteudo = FileHandle.open(arquivo);
                                 final AbaCodigoFonte abaCodigoFonte = AbaCodigoFonte.novaAba();
 
                                 abaCodigoFonte.setCodigoFonte(conteudo, arquivo, true);
 
                                 getPainelTabulado().add(abaCodigoFonte);
-                            } catch (Exception excecao) {
+                            }
+                            catch (Exception excecao)
+                            {
                                 PortugolStudio.getInstancia().getTratadorExcecoes().exibirExcecao(excecao);
                             }
                         }
@@ -209,11 +273,15 @@ public final class TelaPrincipal extends JFrame {
         }
     }
 
-    public void focarJanela() {
-        SwingUtilities.invokeLater(new Runnable() {
+    public void focarJanela()
+    {
+        SwingUtilities.invokeLater(new Runnable()
+        {
             @Override
-            public void run() {
-                if (janelaMinimizada()) {
+            public void run()
+            {
+                if (janelaMinimizada())
+                {
                     restaurarJanela();
                 }
 
@@ -223,34 +291,44 @@ public final class TelaPrincipal extends JFrame {
         });
     }
 
-    private boolean janelaMinimizada() {
+    private boolean janelaMinimizada()
+    {
         return (getExtendedState() & JFrame.ICONIFIED) == JFrame.ICONIFIED;
     }
 
-    private void restaurarJanela() {
+    private void restaurarJanela()
+    {
         setExtendedState(getExtendedState() & (~JFrame.ICONIFIED));
     }
 
-    private boolean arquivoJaEstaAberto(File arquivo) {
+    private boolean arquivoJaEstaAberto(File arquivo)
+    {
         AbaCodigoFonte aba = obterAbaArquivo(arquivo);
 
         return aba != null;
     }
 
-    public AbaCodigoFonte obterAbaArquivo(File arquivo) {
-        for (Aba aba : getPainelTabulado().getAbas(AbaCodigoFonte.class)) {
+    public AbaCodigoFonte obterAbaArquivo(File arquivo)
+    {
+        for (Aba aba : getPainelTabulado().getAbas(AbaCodigoFonte.class))
+        {
             AbaCodigoFonte abaCodigoFonte = (AbaCodigoFonte) aba;
             PortugolDocumento documento = abaCodigoFonte.getPortugolDocumento();
 
-            if (documento.getFile() != null) {
-                try {
+            if (documento.getFile() != null)
+            {
+                try
+                {
                     Path caminhoArquivoAba = documento.getFile().toPath();
                     Path caminhoArquivoAbrir = arquivo.toPath();
 
-                    if (Files.isSameFile(caminhoArquivoAba, caminhoArquivoAbrir)) {
+                    if (Files.isSameFile(caminhoArquivoAba, caminhoArquivoAbrir))
+                    {
                         return abaCodigoFonte;
                     }
-                } catch (IOException excecao) {
+                }
+                catch (IOException excecao)
+                {
                     LOGGER.log(Level.SEVERE, String.format("Erro ao verificar se o arquivo '%s' já estava aberto em alguma aba", arquivo.getAbsolutePath()), excecao);
                 }
             }
@@ -259,15 +337,18 @@ public final class TelaPrincipal extends JFrame {
         return null;
     }
 
-    private void fecharAplicativo() {
+    private void fecharAplicativo()
+    {
         painelTabuladoPrincipal.fecharTodasAbas(AbaCodigoFonte.class);
 
-        if (!painelTabuladoPrincipal.temAbaAberta(AbaCodigoFonte.class)) {
+        if (!painelTabuladoPrincipal.temAbaAberta(AbaCodigoFonte.class))
+        {
             PortugolStudio.getInstancia().finalizar(0);
         }
     }
 
-    public PainelTabuladoPrincipal getPainelTabulado() {
+    public PainelTabuladoPrincipal getPainelTabulado()
+    {
         return painelTabuladoPrincipal;
     }
 

--- a/src/br/univali/ps/ui/abas/AbaCodigoFonte.java
+++ b/src/br/univali/ps/ui/abas/AbaCodigoFonte.java
@@ -1176,7 +1176,8 @@ public final class AbaCodigoFonte extends Aba implements PortugolDocumentoListen
 
             try {
                 programa = Portugol.compilar(editor.getPortugolDocumento().getCodigoFonte());
-                definirDiretorioTrabalho(programa);
+                programa.setArquivoOrigem(editor.getPortugolDocumento().getFile());
+                definirDiretorioTrabalho(programa);                
 
                 if (programa.getResultadoAnalise().contemAvisos()) {
                     exibirResultadoAnalise(programa.getResultadoAnalise());

--- a/src/br/univali/ps/ui/rstautil/PortugolParser.java
+++ b/src/br/univali/ps/ui/rstautil/PortugolParser.java
@@ -9,6 +9,7 @@ import br.univali.portugol.nucleo.asa.TrechoCodigoFonte;
 import br.univali.portugol.nucleo.mensagens.AvisoAnalise;
 import br.univali.portugol.nucleo.mensagens.ErroSemantico;
 import br.univali.portugol.nucleo.mensagens.ErroSintatico;
+import br.univali.ps.nucleo.NamedThreadFactory;
 import br.univali.ps.nucleo.PortugolStudio;
 import java.awt.Color;
 import java.beans.PropertyChangeListener;
@@ -32,7 +33,7 @@ public final class PortugolParser extends AbstractParser
 
     public static final String PROPRIEDADE_PROGRAMA_COMPILADO = "PROGRAMA_COMPILADO";
 
-    private static final ExecutorService service = Executors.newCachedThreadPool();
+    private static final ExecutorService service = Executors.newCachedThreadPool(new NamedThreadFactory("Portugol-Studio (Parser do RSyntaxTextArea)"));
 
     private static final char[] caracteresParada = new char[]
     {


### PR DESCRIPTION
@elieserdejesus. Por favor, teste e verifique se resolveu o problema do nome no MAC (issue #94). Aproveitei e alterei o projeto para dar nomes mais intuitivos às threads e assim facilitar a depuração usando o profiler.

Além disso, encontrei uma linha na tela de carregamento que referenciava o Java FX, talvez seja essa chamada que esteja bugando as outras partes da interface.

Vou abrir um pull request no núcleo também, pois alterei algumas coisas lá. Você deve fazer pull dos dois projetos para testar.

Se o nome alterar, me avise para que eu faça o merge.