### PR TITLE
Corrigindo o ponto de parada fantasma

### DIFF
--- a/src/br/univali/ps/ui/abas/BuscadorDeLinhasParaveis.java
+++ b/src/br/univali/ps/ui/abas/BuscadorDeLinhasParaveis.java
@@ -98,8 +98,12 @@ public final class BuscadorDeLinhasParaveis extends VisitanteNulo {
 
     private boolean verificaSePodeParar(NoBloco noBloco) {
         if (classesParaveis.contains(noBloco.getClass())) {
-            linhasParaveis.add(noBloco.getTrechoCodigoFonte().getLinha());
-            return true;
+            int linha = noBloco.getTrechoCodigoFonte().getLinha();
+            if (linha >= 0)
+            {
+                linhasParaveis.add(linha);
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
 - O problema estava acontecendo porquem alguns nós da ASA não possuem uma
instância de TrechoCodigoFonte válida. Precisamos saber em que linha do código
o nó está, e quem sabe desta linha é o TrechoCodigoFonte. Quando o TrechoCodigoFonte retornava -1 como índice da linha a coisa toda bugava.
Apenas adicionei uma verificação para só considerar como nó parável aqueles
que possuem um índice de linha válido (maior ou igual a zero).

- Nos testes o bug do ponto de parada fantasma não apareceu mais. Entretanto
esse bug expõe uma coisa que poderíamos trabalhar futuramente. Por exemplo, atualmente é possível colocar um ponto de parada em uma declaração de variável,
mas não é possível fazer isso em uma declação de vetor. Why? Why? Whyyyy?
  Simples! O nó da declaração de variável está retornando um índice de linha válido, mas o nó de declaração de vetor não está. O problema é cabuloso e requer (se não me falha a memória) uma alteração no código que constrói os nós da árvore sintática.