### PR TITLE
Corrigindo fontes nulas no inspector de variáveis

### DIFF
--- a/src/br/univali/ps/ui/inspetor/InspetorDeSimbolos.java
+++ b/src/br/univali/ps/ui/inspetor/InspetorDeSimbolos.java
@@ -28,6 +28,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -764,20 +765,25 @@ public class InspetorDeSimbolos extends JList<ItemDaLista> implements Observador
 
         JPanel panelBotoes = new JPanel();
         panelBotoes.setLayout(new BoxLayout(panelBotoes, BoxLayout.X_AXIS));
+        
         JButton botaoAumentarFonte = new JButton(new AbstractAction("+") {
 
             @Override
             public void actionPerformed(ActionEvent ae) {
-                inspetor.setTamanhoDaFonte(RenderizadorBase.fonteNormal.getSize() + 2);
+                Font fonteNormal = RenderizadorBase.getFonte(RenderizadorBase.TipoFonte.NORMAL);
+                inspetor.setTamanhoDaFonte(fonteNormal.getSize() + 2);
             }
         });
+        
         JButton botaoDiminuirFonte = new JButton(new AbstractAction("-") {
 
             @Override
             public void actionPerformed(ActionEvent ae) {
-                inspetor.setTamanhoDaFonte(RenderizadorBase.fonteNormal.getSize() - 2);
+                Font fonteNormal = RenderizadorBase.getFonte(RenderizadorBase.TipoFonte.NORMAL);
+                inspetor.setTamanhoDaFonte(fonteNormal.getSize() - 2);
             }
         });
+        
         panelBotoes.add(botaoAumentarFonte);
         panelBotoes.add(botaoDiminuirFonte);
         botaoAumentarFonte.doClick();

--- a/src/br/univali/ps/ui/inspetor/RenderizadorBase.java
+++ b/src/br/univali/ps/ui/inspetor/RenderizadorBase.java
@@ -10,6 +10,8 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Stroke;
 import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.JComponent;
 
 /**
@@ -18,6 +20,8 @@ import javax.swing.JComponent;
  */
 abstract class RenderizadorBase extends JComponent {
 
+    private static final Logger LOGGER = Logger.getLogger(RenderizadorBase.class.getName());
+    
     protected static final Color COR_GRADE = new Color(1, 1, 1, 0.35f);
     protected static final Color COR_TEXTO = Color.GRAY;
     protected static final Color COR_NOME = Color.LIGHT_GRAY;
@@ -32,12 +36,48 @@ abstract class RenderizadorBase extends JComponent {
 
     protected ItemDaLista itemDaLista;
 
-    protected static Font fonteNormal = criaFontePadrao();
-    protected static Font fonteDestaque;
-    protected static Font fonteCabecalho;
-    protected static Font fonteCabecalhoDestaque;
+    private static Font fonteNormal = criaFontePadrao();
+    private static Font fonteDestaque;
+    private static Font fonteCabecalho;
+    private static Font fonteCabecalhoDestaque;
     protected static float tamanhoFonte = 12f;
 
+    protected enum TipoFonte {
+        NORMAL, DESTAQUE, CABECALHO, CABECALHO_DESTAQUE
+    }
+    
+    protected static Font getFonte(TipoFonte tipoFonte)
+    {
+        Font fonte = fonteNormal;
+        switch (tipoFonte) {
+            case NORMAL:                // desnecessário (ver a 1ª linha), mantendo aqui somente pela legibilidade
+                fonte = fonteNormal;
+                break;
+            case DESTAQUE:
+                fonte = fonteDestaque;
+                break;
+            case CABECALHO:
+                fonte = fonteCabecalho;
+                break;
+            case CABECALHO_DESTAQUE:
+                fonte = fonteCabecalhoDestaque;
+                break;
+        }
+        
+        if (fonte == null) { 
+            if (fonteNormal != null) {
+                fonte = fonteNormal; // tenta usar a fonteNormal caso tenha dado algum problema nos outros tipos de fonte
+                LOGGER.log(Level.WARNING, "Usando uma fonte genérica, não foi possível obter o tipo de fonte: {0}", tipoFonte);
+            }
+            else {
+                LOGGER.log(Level.SEVERE, "A fonte base (fonteNormal) não é válida! tipoFonte: {0}", tipoFonte);
+                fonte = new Font("Dialog", Font.PLAIN, 12); // cria a fonte padrão que parece que sempre existirá
+            }
+        }
+        
+        return fonte;
+    }
+    
     public RenderizadorBase() {
         super();
         setTamanhoDaFonte(tamanhoFonte);

--- a/src/br/univali/ps/ui/inspetor/RenderizadorBase.java
+++ b/src/br/univali/ps/ui/inspetor/RenderizadorBase.java
@@ -21,7 +21,7 @@ import javax.swing.JComponent;
 abstract class RenderizadorBase extends JComponent {
 
     private static final Logger LOGGER = Logger.getLogger(RenderizadorBase.class.getName());
-    
+
     protected static final Color COR_GRADE = new Color(1, 1, 1, 0.35f);
     protected static final Color COR_TEXTO = Color.GRAY;
     protected static final Color COR_NOME = Color.LIGHT_GRAY;
@@ -45,9 +45,8 @@ abstract class RenderizadorBase extends JComponent {
     protected enum TipoFonte {
         NORMAL, DESTAQUE, CABECALHO, CABECALHO_DESTAQUE
     }
-    
-    protected static Font getFonte(TipoFonte tipoFonte)
-    {
+
+    protected static Font getFonte(TipoFonte tipoFonte) {
         Font fonte = fonteNormal;
         switch (tipoFonte) {
             case NORMAL:                // desnecessário (ver a 1ª linha), mantendo aqui somente pela legibilidade
@@ -63,21 +62,20 @@ abstract class RenderizadorBase extends JComponent {
                 fonte = fonteCabecalhoDestaque;
                 break;
         }
-        
-        if (fonte == null) { 
+
+        if (fonte == null) {
             if (fonteNormal != null) {
                 fonte = fonteNormal; // tenta usar a fonteNormal caso tenha dado algum problema nos outros tipos de fonte
-                LOGGER.log(Level.WARNING, "Usando uma fonte genérica, não foi possível obter o tipo de fonte: {0}", tipoFonte);
             }
             else {
                 LOGGER.log(Level.SEVERE, "A fonte base (fonteNormal) não é válida! tipoFonte: {0}", tipoFonte);
                 fonte = new Font("Dialog", Font.PLAIN, 12); // cria a fonte padrão que parece que sempre existirá
             }
         }
-        
+
         return fonte;
     }
-    
+
     public RenderizadorBase() {
         super();
         setTamanhoDaFonte(tamanhoFonte);

--- a/src/br/univali/ps/ui/inspetor/RenderizadorDeMatriz.java
+++ b/src/br/univali/ps/ui/inspetor/RenderizadorDeMatriz.java
@@ -1,6 +1,7 @@
 package br.univali.ps.ui.inspetor;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -8,7 +9,6 @@ import java.awt.Insets;
 import java.awt.RenderingHints;
 import java.awt.Stroke;
 import javax.swing.Icon;
-import static br.univali.ps.ui.inspetor.RenderizadorBase.fonteNormal;
 
 /**
  *
@@ -35,6 +35,10 @@ class RenderizadorDeMatriz extends RenderizadorBase {
         if (itemDaLista == null) {
             return 20;//retorna um valor default só para ter o que desenhar, em geral isso não deveria acontecer
         }
+        
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+                
         FontMetrics metrics = getFontMetrics(fonteNormal);
         ItemDaListaParaMatriz item = (ItemDaListaParaMatriz) itemDaLista;
         int alturaDoNome = metrics.getAscent();
@@ -47,6 +51,10 @@ class RenderizadorDeMatriz extends RenderizadorBase {
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
         if (itemDaLista != null) {
+            
+            Font fonteNormal = getFonte(TipoFonte.NORMAL);
+            Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+            
             ((Graphics2D)g).setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_GASP);
             Icon icone = itemDaLista.getIcone();
             FontMetrics metrics = g.getFontMetrics(fonteNormal);
@@ -78,6 +86,9 @@ class RenderizadorDeMatriz extends RenderizadorBase {
     }
 
     private int calculaRolagemDasLinhas() {
+        
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        
         ItemDaListaParaMatriz item = ((ItemDaListaParaMatriz) itemDaLista);
         int totalDeLinhas = item.getLinhas();
         int alturaDaLinha = getFontMetrics(fonteNormal).getHeight();
@@ -126,6 +137,12 @@ class RenderizadorDeMatriz extends RenderizadorBase {
      * largura do índice da coluna. Retorna a maior largura encontrada.
      */
     private int getLarguraDaColuna(int indiceDaColuna) {
+        
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+        Font fonteCabecalhoDestaque = getFonte(TipoFonte.CABECALHO_DESTAQUE);
+        Font fonteDestaque = getFonte(TipoFonte.DESTAQUE);
+        
         ItemDaListaParaMatriz item = ((ItemDaListaParaMatriz) itemDaLista);
         int totalDeLinhas = item.getLinhas();
         int maiorLargura = 0;
@@ -181,7 +198,10 @@ class RenderizadorDeMatriz extends RenderizadorBase {
     }
 
     private void desenhaValorDaCelula(Graphics g, String stringDoValor, int linha, int xDaLinha, int larguraDaColuna, int alturaDoCabecalho, int alturaDaLinha, int linhaInicial, boolean podeDestacarEstaCelula) {
-        //String stringDoValor = getStringDoValor(l, c);
+        
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteDestaque = getFonte(TipoFonte.DESTAQUE);
+        
         g.setFont(podeDestacarEstaCelula ? fonteDestaque : fonteNormal);
         FontMetrics metrics = g.getFontMetrics();
         int xDoValor = xDaLinha + larguraDaColuna / 2 - metrics.stringWidth(stringDoValor) / 2;
@@ -224,6 +244,9 @@ class RenderizadorDeMatriz extends RenderizadorBase {
     }
 
     private void desenhaIndiceDaColuna(Graphics g, int colunaAtual, int xDaLinha, int yDaLinha, int larguraDaColuna) {
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+        Font fonteCabecalhoDestaque = getFonte(TipoFonte.CABECALHO_DESTAQUE);
+        
         ItemDaListaParaMatriz item = ((ItemDaListaParaMatriz) itemDaLista);
         String stringIndiceDaColuna = String.valueOf(colunaAtual);
         if (itemDaLista.podeDesenharDestaque() && colunaAtual == item.getUltimaColunaAtualizada()) {
@@ -241,6 +264,10 @@ class RenderizadorDeMatriz extends RenderizadorBase {
     private void desenhaIndiceDaLinha(Graphics g, int linhaAtual, int linhaInicial, int inicioLinhaHorizontal, int margemSuperior, int alturaDaLinha) {
         ItemDaListaParaMatriz item = ((ItemDaListaParaMatriz) itemDaLista);
         String stringIndiceDaLinha = String.valueOf(linhaAtual);
+        
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+        Font fonteCabecalhoDestaque = getFonte(TipoFonte.CABECALHO_DESTAQUE);
+        
         if (itemDaLista.podeDesenharDestaque() && linhaAtual == item.getUltimaLinhaAtualizada()) {
             g.setFont(fonteCabecalhoDestaque);
             g.setColor(COR_DO_CABECALHO_DESTACADO);
@@ -271,10 +298,14 @@ class RenderizadorDeMatriz extends RenderizadorBase {
     }
     
     private int getAlturaDoCabecalho() {
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
         return getFontMetrics(fonteCabecalho).getHeight();
     }
     
     private void desenhaGrade(Graphics g, int totalDeLinhas, int totalDeColunas, int colunaInicial, int linhaInicial, int margemEsquerda, int margemSuperior) {
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteDestaque = getFonte(TipoFonte.DESTAQUE);
+        
         int alturaDaLinha = getFontMetrics(fonteNormal).getHeight();
         int alturaDoCabecalho = getAlturaDoCabecalho();
         int larguraMaximaDoIndiceDeLinha = MARGEM + getFontMetrics(fonteDestaque).stringWidth(String.valueOf(totalDeLinhas - 1));//obtém a largura da string do maior índice de linha

--- a/src/br/univali/ps/ui/inspetor/RenderizadorDeVariavel.java
+++ b/src/br/univali/ps/ui/inspetor/RenderizadorDeVariavel.java
@@ -1,11 +1,11 @@
 package br.univali.ps.ui.inspetor;
 
+import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import javax.swing.Icon;
-import static br.univali.ps.ui.inspetor.RenderizadorBase.fonteNormal;
 
 /**
  *
@@ -16,6 +16,8 @@ class RenderizadorDeVariavel extends RenderizadorBase {
 
     @Override
     protected int getAlturaPreferida() {
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+
         FontMetrics metrics = getFontMetrics(fonteNormal);
         return metrics.getHeight();
     }
@@ -36,6 +38,10 @@ class RenderizadorDeVariavel extends RenderizadorBase {
         if (itemDaLista == null) {
             return;
         }
+        
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteDestaque = getFonte(TipoFonte.DESTAQUE);
+        
         Icon icone = itemDaLista.getIcone();
         
         int x = MARGEM; // x inicial

--- a/src/br/univali/ps/ui/inspetor/RenderizadorDeVetor.java
+++ b/src/br/univali/ps/ui/inspetor/RenderizadorDeVetor.java
@@ -1,12 +1,12 @@
 package br.univali.ps.ui.inspetor;
 
+import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Stroke;
 import javax.swing.Icon;
-import static br.univali.ps.ui.inspetor.RenderizadorBase.fonteNormal;
 
 /**
  *
@@ -28,6 +28,8 @@ class RenderizadorDeVetor extends RenderizadorBase {
 
     @Override
     protected int getAlturaPreferida() {
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
         FontMetrics metrics = getFontMetrics(fonteNormal);
         int alturaDoNome = metrics.getAscent();
         int alturaCabecalho = getFontMetrics(fonteCabecalho).getHeight();
@@ -38,6 +40,9 @@ class RenderizadorDeVetor extends RenderizadorBase {
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
         if (itemDaLista != null) {
+            Font fonteNormal = getFonte(TipoFonte.NORMAL);
+            Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+            
             ((Graphics2D)g).setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_GASP);
             Icon icone = itemDaLista.getIcone();
             FontMetrics metrics = g.getFontMetrics(fonteNormal);
@@ -89,6 +94,12 @@ class RenderizadorDeVetor extends RenderizadorBase {
      * largura do índice da coluna. Retorna a maior largura encontrada.
      */
     private int getLarguraDaColuna(int indiceDaColuna) {
+        
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+        Font fonteCabecalhoDestaque = getFonte(TipoFonte.CABECALHO_DESTAQUE);
+        Font fonteDestaque = getFonte(TipoFonte.DESTAQUE);
+        
         ItemDaListaParaVetor item = ((ItemDaListaParaVetor) itemDaLista);
         String stringDoValor = getStringDoValor(indiceDaColuna);
         String stringDoIndice = String.valueOf(indiceDaColuna);
@@ -110,6 +121,11 @@ class RenderizadorDeVetor extends RenderizadorBase {
     }
 
     private void desenhaGrade(Graphics g, int totalDeColunas, int colunaInicial, int margemEsquerda, int margemSuperior) {
+        Font fonteNormal = getFonte(TipoFonte.NORMAL);
+        Font fonteCabecalho = getFonte(TipoFonte.CABECALHO);
+        Font fonteCabecalhoDestaque = getFonte(TipoFonte.CABECALHO_DESTAQUE);
+        Font fonteDestaque = getFonte(TipoFonte.DESTAQUE);
+        
         int alturaDaLinha = g.getFontMetrics(fonteNormal).getHeight();
         int inicioLinhaHorizontal = margemEsquerda;
         int xDaLinha = inicioLinhaHorizontal;


### PR DESCRIPTION
- Aparentemente em algumas máquinas as fontes usadas no inspetor de variáveis não são criadas corretamente e isso acaba gerando NullPointerException quando um símbolo é arrastado para o inspetor.