### PR TITLE
Corrigindo o bug do programa anterior sendo executado (fix #206)

### DIFF
--- a/src/br/univali/ps/ui/abas/AbaCodigoFonte.java
+++ b/src/br/univali/ps/ui/abas/AbaCodigoFonte.java
@@ -974,8 +974,6 @@ public final class AbaCodigoFonte extends Aba implements PortugolDocumentoListen
                 Set<Integer> linhasParaveis = buscadorDeLinhasParaveis.getLinhasParaveis(programa);
                 editor.getTextArea().criarPontosDeParadaDesativados(linhasParaveis);
                 
-                precisaRecompilar = true;
-                
                 //Gambiarra pro botão não sumir :3
                 SwingUtilities.invokeLater(() -> {
                     painelEditor.repaint();
@@ -1605,6 +1603,8 @@ public final class AbaCodigoFonte extends Aba implements PortugolDocumentoListen
     @Override
     public void documentoModificado(boolean modificado)
     {
+        precisaRecompilar = true; // sempre que o documento é modificado precisamos descartar o programa já compilado e compilar novamente
+        
         SwingUtilities.invokeLater(() -> {
         
             atualizaStatusAcaoSalvar(modificado);


### PR DESCRIPTION
- Apenas setei a flag 'precisaRecompilar' no listener de "documentoModificado". Esse listener é invocado assim que a mudança no código é realizada. O código anterior setava essa mesma flag (precisaRecompilar) quando o listener do parser disparava. Esse listener do parser tem um delay, e se o usuário fosse mais rápido que esse delay (SHIFT + F6) o código antigo era executado.