### PR TITLE
Corrigindo o erro nos forms que usavam a classe Caminhos (fix #253)

### DIFF
--- a/src/br/univali/ps/nucleo/Caminhos.java
+++ b/src/br/univali/ps/nucleo/Caminhos.java
@@ -35,10 +35,18 @@ public final class Caminhos
     {
         if (!rodandoNoNetbeans())
         {
-            CodeSource localCodigo = Caminhos.class.getProtectionDomain().getCodeSource();
-            URL local = localCodigo.getLocation();
+            try
+            {
+                CodeSource localCodigo = Caminhos.class.getProtectionDomain().getCodeSource();
+                URL local = localCodigo.getLocation();
 
-            return new File(URI.create(local.toExternalForm())).getParentFile().getParentFile();
+                return new File(URI.create(local.toExternalForm())).getParentFile().getParentFile();
+            }
+            catch(Exception ex)
+            {
+                LOGGER.log(Level.SEVERE, null, ex);
+                return new File(".");
+            }
         }
         else
         {


### PR DESCRIPTION
@AdsonEsteves , esse PR corrige a issue #253. Testei bem rapidamente aqui, podes testar com mais calma? Acho que é impotrante testar "fora" do NetBeans. Podes gerar a versão multiplataforma para testar ou então substituir o Portugol-Studio.jar do instalador pelo arquivo modificado.
