### PR TITLE
Corrigindo ordem dos arquivos recentes

### DIFF
--- a/src/br/univali/ps/ui/paineis/PainelExemplos.java
+++ b/src/br/univali/ps/ui/paineis/PainelExemplos.java
@@ -139,7 +139,7 @@ public class PainelExemplos extends javax.swing.JPanel implements Themeable{
             textRecentes.setVisible(true);
         }
         Object [] ar = files.toArray();
-        for (int i=(files.size()-1); i>0; i--) {
+        for (int i=(files.size() - 1); i >= 0; i--) {
         File recente = (File) ar[i];
             if(!recente.exists())
             {

--- a/src/br/univali/ps/ui/paineis/PainelExemplos.java
+++ b/src/br/univali/ps/ui/paineis/PainelExemplos.java
@@ -138,7 +138,9 @@ public class PainelExemplos extends javax.swing.JPanel implements Themeable{
         {
             textRecentes.setVisible(true);
         }
-        for (File recente : files) {
+        Object [] ar = files.toArray();
+        for (int i=(files.size()-1); i>0; i--) {
+        File recente = (File) ar[i];
             if(!recente.exists())
             {
                 arquivoRemovido = true;


### PR DESCRIPTION
Os arquivos recentes abertos por último sempre apareciam no fim da lista dos recentes. Foi realizada a correção para que eles aparecem na primeira posição da direita para esquerda.