### PR TITLE
Corrigindo problema dos avisos desaparecendo (fix #198)

### DIFF
--- a/src/br/univali/ps/ui/rstautil/PortugolParser.java
+++ b/src/br/univali/ps/ui/rstautil/PortugolParser.java
@@ -181,9 +181,8 @@ public class PortugolParser extends AbstractParser
         try 
         {
             String codigo = documento.getText(0, documento.getLength());
-            if (!codigo.isEmpty() && !codigo.equals(ultimoCodigoAnalisado)) // não compila para análise se o codigo é igual ao último código 'parseado'
+            if (!codigo.isEmpty()) 
             {
-                ultimoCodigoAnalisado = codigo;
                 
                 Programa programa = Portugol.compilarParaAnalise(codigo);
 
@@ -191,8 +190,11 @@ public class PortugolParser extends AbstractParser
                 {
                     notificarErrosAvisos(programa.getResultadoAnalise(), documento, resultado);
                 }
-
-                support.firePropertyChange(PROPRIEDADE_PROGRAMA_COMPILADO, null, programa);
+                if(!codigo.equals(ultimoCodigoAnalisado)) // não precisa atualizar outros componentes se o código continua o mesmo
+                {
+                    ultimoCodigoAnalisado = codigo;
+                    support.firePropertyChange(PROPRIEDADE_PROGRAMA_COMPILADO, null, programa);
+                }
             }
         }
         catch (ErroCompilacao erroCompilacao) 

--- a/src/logging.properties
+++ b/src/logging.properties
@@ -44,7 +44,7 @@ handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 
 # --- ConsoleHandler --- 
 # Override of global logging level 
-java.util.logging.ConsoleHandler.level=SEVERE
+java.util.logging.ConsoleHandler.level=INFO
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 
 


### PR DESCRIPTION
O problema se dava pelo parser ser chamado quando o programa era finalizado (ou iniciado quando tinha o forceReparsing), e a analise ser pulada, assim passando pra frente resultados vazios.