### PR TITLE
:bug: Restaurando arquivos da JDK que impediam a reinicialização. Fix #385

### DIFF
--- a/installer/jdk-minify-profile.json
+++ b/installer/jdk-minify-profile.json
@@ -12,7 +12,6 @@
         "jdk/jre/lib/desktop",
         "jdk/jre/lib/ext",
         "jdk/jre/lib/jfr",
-        "jdk/jre/lib/management",
         "jdk/jre/lib/oblique-fonts",
 
         "jdk/jre/plugin",
@@ -24,7 +23,6 @@
         "jdk/jre/lib/javaws.jar",
         "jdk/jre/lib/jfr.jar",
         "jdk/jre/lib/jfxswt.jar",
-        "jdk/jre/lib/management-agent.jar",
         "jdk/jre/lib/plugin.jar",
 
         "jdk/jre/THIRDPARTYLICENSEREADME-JAVAFX.txt",
@@ -147,7 +145,6 @@
         "jdk/jre/bin/jfxmedia.dll",
         "jdk/jre/bin/jfxwebkit.dll",
         "jdk/jre/bin/jfr.dll",
-        "jdk/jre/bin/management.dll",
         "jdk/jre/bin/prism_common.dll",
         "jdk/jre/bin/prism_d3d.dll",
         "jdk/jre/bin/prism_es2.dll",
@@ -306,7 +303,6 @@
         "jdk/jre/lib/i386/libjfxmedia.so",
         "jdk/jre/lib/i386/libjfxwebkit.so",
         "jdk/jre/lib/i386/libjsig.so",
-        "jdk/jre/lib/i386/libmanagement.so",
         "jdk/jre/lib/i386/libprism_common.so",
         "jdk/jre/lib/i386/libprism_es2.so",
         "jdk/jre/lib/i386/libprism_sw.so"
@@ -382,7 +378,6 @@
         "jdk/jre/lib/amd64/libjfxmedia.so",
         "jdk/jre/lib/amd64/libjfxwebkit.so",
         "jdk/jre/lib/amd64/libjsig.so",
-        "jdk/jre/lib/amd64/libmanagement.so",
         "jdk/jre/lib/amd64/libprism_common.so",
         "jdk/jre/lib/amd64/libprism_es2.so",
         "jdk/jre/lib/amd64/libprism_sw.so"


### PR DESCRIPTION
Alguns arquivos da JDK haviam sido removidos durante a minimização. A falta destes arquivos fez com que algumas classes utilizadas na funcionalidade de reinicialização não fossem mais encontradas. Para resolver isso, configuramos o minimizador da JDK para manter estes arquivos.

![image](http://www.cosbailbonds.com/uploads/7/5/6/2/75628843/93798_orig.gif)

**IMPORTANTE:** Após integrar este pull request, será necessário apagar as pastas do java no diretório de build do installer, para que o gradle baixe novamente o java e faça a minimização preservando estes arquivos.