### PR TITLE
:gem: Limpando o console de verdade no Linux

### DIFF
--- a/console/src/main/java/br/univali/portugol/Console.java
+++ b/console/src/main/java/br/univali/portugol/Console.java
@@ -43,6 +43,18 @@ public final class Console implements Entrada, Saida, ObservadorExecucao
     private static boolean aguardarParaSair = true;
     
     private Programa programa = null;
+    
+    private static boolean isLinux = false;
+    
+    static 
+    {
+    	String osName = System.getProperty("os.name");
+    
+    	if (osName != null && osName.indexOf("nux") >= 0)
+    	{
+    		isLinux = true;
+    	}
+    }
 
     private static void inicializarMecanismoLog()
     {
@@ -432,7 +444,10 @@ public final class Console implements Entrada, Saida, ObservadorExecucao
     @Override
     public void limpar()
     {
-
+    	if (isLinux)
+    	{
+    		System.out.print("\033c");
+    	}
     }
 
     @Override


### PR DESCRIPTION
Este pull request acrescenta um melhoria específica para o Linux.

Quando o programa é rodado via terminal do sistema operacional utilizando o comando ```portugol-console algoritmo.por```, se a função "limpa" for chamada no código, a tela do terminal é limpada de verdade. Antes isso não acontecia e os caracteres iam se acumulando na tela.

Algoritmo para testes:

```
programa
{
	inclua biblioteca Util --> u
	inclua biblioteca Tipos --> tp
	inclua biblioteca Matematica --> mat
	inclua biblioteca Texto --> txt

	// Número de caracteres '=' que formam a barra. Desconsiderando as bordas formadas pelos caracteres '[' e ']'
	// Você pode mudar o comprimento da barra à vontade que o resultado não será afetado.
	// Escolhemos 78 caracteres porque o tamanho padrão dos consoles é 80, ou seja, 78 caracteres '=' + '[' e ']' = 80
	const inteiro COMPRIMENTO_BARRA = 78

	const inteiro TAMANHO_VETOR = 287

	inteiro vetor[TAMANHO_VETOR]
	
	
	funcao inicio()
	{
		real percentual = 0.0
		
		para (inteiro indice = 1; indice <= TAMANHO_VETOR; indice++)
		{
			vetor[indice - 1] = (indice + (indice * 2)) * 3

			limpa()

			escreva("Preenchendo vetor. Item " + indice + " de " + TAMANHO_VETOR + "...\n\n")

            	// Mutiplicar por 1.0 converte o valor em real antes de ser passado para a função
            	percentual = indice / (TAMANHO_VETOR * 1.0)

            	desenha_barra_carregamento(percentual)
            	
            	u.aguarde(50)
		}

		escreva("\n\n")
		escreva("Vetor preenchido com sucesso!")
		escreva("\n\n")
	}


	funcao desenha_barra_carregamento(real percentual)
	{
		// Se o percentual for maior que 100%, transforma em 100%
		percentual = mat.menor_numero(percentual, 1.0)

		// Se o percentual for menor que 0% transforma em 0%
		percentual = mat.maior_numero(percentual, 0.0)

		// Calcula quantos passos devem ser dados de acordo com o percentual e
		// coloca em uma variável auxiliar temporária		
		real passos_aux = COMPRIMENTO_BARRA * percentual
		
		// Arredonda a quantidade de passos para que fique sem nenhuma casa decimal.
		// Por exemplo, se a quantidade de passos for for 23.79, ficará 24.00
		passos_aux = mat.arredondar(passos_aux, 0)

		// Armazena a quantidade de passos correspondente ao percentual que já foi concluído
		inteiro passos = tp.real_para_inteiro(passos_aux)

		// O percentual é representado como um número real entre 0.0 e 1.0. Antes de desenhar o percentual na tela, 
		// é necessário converter para um número entre 0.0 e 100.0. Por isso multiplicamos o valor por 100.0.
		// Além disso arredondamos o valor para duas casas decimais depois da vírgula
		percentual = mat.arredondar(percentual * 100.0, 2)
		

		// Converte o percentual que está em número real para sua representação textual
		cadeia texto_percentual = tp.real_para_cadeia(percentual)

		texto_percentual = " " + texto_percentual + "% "

		// Calcula a posição inicial do texto dentro da barra de progresso.
		// É necessário somar +1 porque a variável passo atual começa com o valor 1
		inteiro posicao_inicial_texto = 1 + (COMPRIMENTO_BARRA / 2) - (txt.numero_caracteres(texto_percentual) / 2)

		inteiro posicao_final_texto = posicao_inicial_texto + txt.numero_caracteres(texto_percentual)
		
		escreva("[")

		inteiro passo_atual = 1

		enquanto (passo_atual <= COMPRIMENTO_BARRA)
		{
			se (passo_atual == posicao_inicial_texto)
			{
				escreva(texto_percentual)

				// Pula a quantidade de caracteres do texto de percentual. Também diminuímos 1 unidade, pois
				// ela será somada novamente à variavel "passo_atual" no final do laço 
				passo_atual = passo_atual + txt.numero_caracteres(texto_percentual) - 1				
			}
			senao se (passo_atual <= passos)
			{
				escreva("=")
			}
			senao
			{
				escreva(" ")
			}			

			passo_atual = passo_atual + 1
		}

		escreva("]")
	}
}
```
