### PR TITLE
Corrigindo caminhos novamente (fix #389)

### DIFF
--- a/ide/src/main/java/br/univali/ps/nucleo/Caminhos.java
+++ b/ide/src/main/java/br/univali/ps/nucleo/Caminhos.java
@@ -157,16 +157,9 @@ public final class Caminhos
     public static boolean rodandoEmDesenvolvimento()
     {
         String path = new File(".").getAbsolutePath();
-        
-        if (rodandoNoWindows()) {
-            return !path.endsWith("Portugol Studio\\.");
-        }
-        else if (rodandoNoLinux()) {
-            return !path.endsWith("portugol-studio/.");
-        }
-       
+                      
         //Mac - quando está instalado o executável do PS fica em /Applications/Portugol Studio.app/Contents/MacOSx
-        return !path.contains("Portugol Studio.app");
+        return (!path.contains("Portugol Studio.app")) && path.endsWith("ide\\.");
      }
 
     public static boolean rodandoNoWindows()


### PR DESCRIPTION
Estou verificando agora se a pasta atual é compativel com o repositório, ao invés de verificar a pasta de instalação em cada plataforma.
Corrige #389 

Gerei instaladores com a modificação e estão no draft da 2.6.3
baixem, instalem e vejam se ocorreu algum problema nos caminhos (se os exemplos apareceram na aba inicial)
podem fazer isso ao abrir o portugol normalmente, abrir um .por, ou vários etc.