### PR TITLE
:bug: Ignorando exceção de problema da JDK (fix #425)

### DIFF
--- a/ide/src/main/java/br/univali/ps/nucleo/TratadorExcecoes.java
+++ b/ide/src/main/java/br/univali/ps/nucleo/TratadorExcecoes.java
@@ -147,6 +147,10 @@ public final class TratadorExcecoes implements Thread.UncaughtExceptionHandler
         {
             LOGGER.log(Level.WARNING, "Exceção não identificada", excecao);
         }
+        else if (excecao.getMessage().contains("component must be showing on the screen to determine its location") && excecao.getMessage().contains("javax.swing.text.JTextComponent$InputMethodRequestsHandler.getTextLocation"))
+        {
+            //ignorar até JDK ser atualizada para versão 9
+        }
         else
         {
             exibirExcecao(new ExcecaoAplicacao(excecao, ExcecaoAplicacao.Tipo.ERRO_PROGRAMA));


### PR DESCRIPTION
Aparentemente este erro (#425) é da própria JDK:

https://bugs.openjdk.java.net/browse/JDK-8179665

E este problema foi resolvido na versão 9 da JDK, que ainda não foi lançada. De acordo com a issue, este erro se capturado, pode ser ignorado pois não causa maiores problemas.
Então até ser lançada a nova JDK, a melhor maneira é ignorar o erro, quando for capturado.