### PR TITLE
:date: Modificando botões da tela renomear simbolo

### DIFF
--- a/ide/src/main/java/br/univali/ps/ui/telas/TelaRenomearSimbolo.form
+++ b/ide/src/main/java/br/univali/ps/ui/telas/TelaRenomearSimbolo.form
@@ -195,11 +195,6 @@
             <Property name="rows" type="int" value="1"/>
           </Layout>
           <SubComponents>
-            <Component class="com.alee.laf.button.WebButton" name="botaoCancelar">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Cancelar"/>
-              </Properties>
-            </Component>
             <Component class="com.alee.laf.button.WebButton" name="botaoAceitar">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Aceitar"/>
@@ -207,6 +202,11 @@
               <Events>
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="botaoAceitarActionPerformed"/>
               </Events>
+            </Component>
+            <Component class="com.alee.laf.button.WebButton" name="botaoCancelar">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Cancelar"/>
+              </Properties>
             </Component>
           </SubComponents>
         </Container>

--- a/ide/src/main/java/br/univali/ps/ui/telas/TelaRenomearSimbolo.java
+++ b/ide/src/main/java/br/univali/ps/ui/telas/TelaRenomearSimbolo.java
@@ -109,8 +109,8 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
         
         if(WeblafUtils.weblafEstaInstalado()){
             WeblafUtils.configuraWebLaf(info);
-            WeblafUtils.configurarBotao(botaoAceitar,ColorController.FUNDO_ESCURO, ColorController.COR_LETRA_TITULO, ColorController.FUNDO_MEDIO, ColorController.COR_LETRA, 4);
-            WeblafUtils.configurarBotao(botaoCancelar,ColorController.FUNDO_ESCURO, ColorController.COR_LETRA_TITULO, ColorController.FUNDO_MEDIO, ColorController.COR_LETRA, 4);
+            WeblafUtils.configurarBotao(botaoAceitar,ColorController.FUNDO_ESCURO, ColorController.COR_LETRA_TITULO, ColorController.AMARELO, ColorController.COR_LETRA, 4);
+            WeblafUtils.configurarBotao(botaoCancelar,ColorController.FUNDO_ESCURO, ColorController.COR_LETRA_TITULO, ColorController.VERMELHO, ColorController.COR_LETRA, 4);
             WeblafUtils.configuraWebLaf(campoNomeAtual, 2, 2);
             WeblafUtils.configuraWebLaf(campoNovoNome, 2, 2);
         }        
@@ -191,7 +191,7 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
                     info.setVisible(false);
                 }
 
-                acaoAceitar.setEnabled(true);
+                acaoAceitar.setEnabled(true);   
             }
             catch (ErroAoRenomearSimbolo ex)
             {
@@ -226,6 +226,7 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
             info.setForeground(ColorController.VERMELHO);
             acaoAceitar.setEnabled(false);
         }
+        alternarCorBotaoAceitar();
     }
 
     private void dispararTimerAtualizacao()
@@ -248,6 +249,7 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
         {
             timer.restart();
         }
+        alternarCorBotaoAceitar();
     }
 
     public void exibir(String codigoFonte, int linha, int coluna) throws ExcecaoAplicacao
@@ -289,6 +291,7 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
                 throw new ExcecaoAplicacao(ex, ExcecaoAplicacao.Tipo.ERRO_PROGRAMA);
             }
         }
+        alternarCorBotaoAceitar();
     }
 
     private void definirTituloJanela()
@@ -341,6 +344,13 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
             }
         }
     }
+    
+    private void alternarCorBotaoAceitar(){
+        if(acaoAceitar.isEnabled())
+            WeblafUtils.configurarBotao(botaoAceitar,ColorController.FUNDO_ESCURO, ColorController.COR_LETRA_TITULO, ColorController.AMARELO, ColorController.COR_LETRA, 4);
+        else
+            WeblafUtils.configurarBotao(botaoAceitar,ColorController.FUNDO_MEDIO, ColorController.COR_LETRA_TITULO, ColorController.FUNDO_MEDIO, ColorController.COR_LETRA, 4);
+    }
 
     public boolean usuarioAceitouRenomear()
     {
@@ -373,8 +383,8 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
         campoNomeAtual = new javax.swing.JTextField();
         botoes = new javax.swing.JPanel();
         jPanel1 = new javax.swing.JPanel();
-        botaoCancelar = new com.alee.laf.button.WebButton();
         botaoAceitar = new com.alee.laf.button.WebButton();
+        botaoCancelar = new com.alee.laf.button.WebButton();
 
         setMinimumSize(new java.awt.Dimension(160, 160));
         setPreferredSize(new java.awt.Dimension(350, 175));
@@ -434,9 +444,6 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
         jPanel1.setOpaque(false);
         jPanel1.setLayout(new java.awt.GridLayout(1, 2, 10, 0));
 
-        botaoCancelar.setText("Cancelar");
-        jPanel1.add(botaoCancelar);
-
         botaoAceitar.setText("Aceitar");
         botaoAceitar.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -444,6 +451,9 @@ public class TelaRenomearSimbolo extends javax.swing.JPanel {
             }
         });
         jPanel1.add(botaoAceitar);
+
+        botaoCancelar.setText("Cancelar");
+        jPanel1.add(botaoCancelar);
 
         botoes.add(jPanel1, java.awt.BorderLayout.EAST);
 


### PR DESCRIPTION
* Modificando ordem:
Em alguns textos dizem que faz mais sentido o botão de afirmação vir primeiro. [Link](https://ux.stackexchange.com/questions/1072/ok-cancel-on-left-right)
* Alterando cor ao sobrepor botões

Pics:
* Tema Dark:
![renomear_dark1](https://user-images.githubusercontent.com/21344756/32912114-379f3090-caf5-11e7-8523-578fee17751e.png)
Mouse sobre aceitar:
![renomear_dark2](https://user-images.githubusercontent.com/21344756/32912115-37c27faa-caf5-11e7-96e2-0b5f75813ea8.png)
Mouse sobre cancelar:
![renomear_dark3](https://user-images.githubusercontent.com/21344756/32912116-37e07870-caf5-11e7-9d97-5817b4dd1838.png)

* Tema Light:
![renomear_light1](https://user-images.githubusercontent.com/21344756/32912198-6e3fe39c-caf5-11e7-94db-34495d549fa7.png)
Mouse sobre aceitar:
![renomear_light2](https://user-images.githubusercontent.com/21344756/32912199-6e5dfd1e-caf5-11e7-9f4e-7d952380d0f0.png)
Mouse sobre cancelar:
![renomear_light3](https://user-images.githubusercontent.com/21344756/32912196-6e213726-caf5-11e7-9864-e1ed7d3a967e.png)
