### PR TITLE
:bug: trocando para aba console ao acontecer erro de execução (fix #580)

### DIFF
--- a/ide/src/main/java/br/univali/ps/ui/abas/AbaCodigoFonte.java
+++ b/ide/src/main/java/br/univali/ps/ui/abas/AbaCodigoFonte.java
@@ -2637,6 +2637,14 @@ public final class AbaCodigoFonte extends Aba implements PortugolDocumentoListen
                 } else if (resultadoExecucao.getModoEncerramento() == ModoEncerramento.ERRO) {
                     console.escreverNoConsole("\nOcorreu um erro durante a execução do programa: " + resultadoExecucao.getErro().getMensagem());
                     console.escreverNoConsole("\nLinha: " + resultadoExecucao.getErro().getLinha() + ", Coluna: " + (resultadoExecucao.getErro().getColuna() + 1));
+                    Timer timer = new Timer(100, new AbstractAction() {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            painelSaida.selecionaConsole();
+                        }
+                    });
+                    timer.setRepeats(false);
+                    timer.start();                    
                 } else if (resultadoExecucao.getModoEncerramento() == ModoEncerramento.INTERRUPCAO) {
                     console.escreverNoConsole("\nO programa foi interrompido!");
                 }

--- a/ide/src/main/java/br/univali/ps/ui/abas/AbaCodigoFonte.java
+++ b/ide/src/main/java/br/univali/ps/ui/abas/AbaCodigoFonte.java
@@ -1052,7 +1052,7 @@ public final class AbaCodigoFonte extends Aba implements PortugolDocumentoListen
                 executar(estadoInicial); // estado inicial da execução: executa até o próximo Ponto de parada ou "passo a passo"
             } catch (ErroCompilacao erroCompilacao) {
                 exibirResultadoAnalise(erroCompilacao.getResultadoAnalise());
-
+                
                 setaAtivacaoBotoesExecucao(true); // pode executar                
             } catch (Exception ex) {
                 PortugolStudio.getInstancia().getTratadorExcecoes().exibirExcecao(ex);
@@ -2036,13 +2036,13 @@ public final class AbaCodigoFonte extends Aba implements PortugolDocumentoListen
                 programaCompilado.setArquivoOrigem(editor.getPortugolDocumento().getFile());
                 definirDiretorioTrabalho(programaCompilado);
 
-                if (programaCompilado.getResultadoAnalise().contemAvisos()) {
-                    SwingUtilities.invokeLater(() -> {
-                        exibirResultadoAnalise(programaCompilado.getResultadoAnalise());
-                    });
-                }
 
                 ResultadoAnalise resultadoAnalise = programaCompilado.getResultadoAnalise();
+                if (resultadoAnalise.contemAvisos()) {
+                    SwingUtilities.invokeLater(() -> {
+                        exibirResultadoAnalise(resultadoAnalise);
+                    });
+                }
                 if (!resultadoAnalise.contemErros()) {
                     programaCompilado.adicionarObservadorExecucao(new ObservadorExecucao());
                     programaCompilado.adicionarObservadorExecucao(editor);
@@ -2640,6 +2640,7 @@ public final class AbaCodigoFonte extends Aba implements PortugolDocumentoListen
                 } else if (resultadoExecucao.getModoEncerramento() == ModoEncerramento.INTERRUPCAO) {
                     console.escreverNoConsole("\nO programa foi interrompido!");
                 }
+                painelSaida.selecionaConsole();
                 ocultarPainelSaida();
                 acaoInterromper.setEnabled(false);
                 setaAtivacaoBotoesExecucao(true);


### PR DESCRIPTION
Quando há um erro de execução no meio da execução de um código, a aba saída é sempre trocada para a console.