### PR TITLE
Removendo função sorteia da biblioteca Util (Closes #606)

### DIFF
--- a/core/src/main/java/br/univali/portugol/nucleo/bibliotecas/Util.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/bibliotecas/Util.java
@@ -184,34 +184,6 @@ public final class Util extends Biblioteca
     }
 
     @DocumentacaoFuncao(
-            descricao = "Sorteia um número aleatório entre os valores mínimo e máximo especificados",
-            parametros =
-            {
-                @DocumentacaoParametro(nome = "minimo", descricao = "o menor número que pode ser sorteado")
-                ,
-            @DocumentacaoParametro(nome = "maximo", descricao = "o maior número que pode ser sorteado")
-            },
-            retorno = "O número sorteado",
-            autores =
-            {
-                @Autor(nome = "Luiz Fernando Noschang", email = "noschang@univali.br")
-            }
-    )
-    public int sorteia(int minimo, int maximo) throws ErroExecucaoBiblioteca, InterruptedException
-    {
-        if (minimo > maximo)
-        {
-            throw new ErroExecucaoBiblioteca(String.format("O valor mínimo (%d) é maior do que o valor máximo (%d)", minimo, maximo));
-        }
-        else if (minimo == maximo)
-        {
-            throw new ErroExecucaoBiblioteca(String.format("Os valores mínimo e máximo são iguais: %d", minimo));
-        }
-
-        return minimo + random.nextInt(maximo + 1 - minimo);
-    }
-
-    @DocumentacaoFuncao(
             descricao = "Pausa a execução do programa durante o intervalo de tempo especificado",
             parametros =
             {

--- a/ide/src/main/assets/exemplos/bibliotecas/graficos/fractal_fern.por
+++ b/ide/src/main/assets/exemplos/bibliotecas/graficos/fractal_fern.por
@@ -99,7 +99,7 @@ programa
 
 	funcao real sortear()
 	{
-		retorne u.sorteia(0, 1000) / 1000.0
+		retorne sorteia(0, 1000) / 1000.0
 	}
      
 	funcao  desenhar_proximo_ponto()
@@ -147,7 +147,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 2704; 
+ * @POSICAO-CURSOR = 2523; 
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;
  * @FILTRO-ARVORE-TIPOS-DE-DADO = inteiro, real, logico, cadeia, caracter, vazio;

--- a/ide/src/main/assets/exemplos/bibliotecas/graficos/paint.por
+++ b/ide/src/main/assets/exemplos/bibliotecas/graficos/paint.por
@@ -323,8 +323,8 @@ programa
 		
 		para (inteiro i = 1; i <= (tamanho / 2); i++)
 		{
-			sx = u.sorteia(x, x + tamanho)
-			sy = u.sorteia(y, y + tamanho)
+			sx = sorteia(x, x + tamanho)
+			sy = sorteia(y, y + tamanho)
 
 			g.desenhar_ponto(sx, sy)
 		}
@@ -509,6 +509,10 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 44; 
- * @DOBRAMENTO-CODIGO = [50, 64, 73, 78, 93, 123, 121, 105, 140, 152, 191, 195, 205, 209, 168, 217, 239, 243, 237, 262, 295, 305, 323, 314, 332, 343, 341, 360, 358, 351, 369, 402, 400, 389, 413, 411, 423, 421, 431, 436, 441, 470, 483];
+ * @POSICAO-CURSOR = 8; 
+ * @DOBRAMENTO-CODIGO = [50, 64, 73, 78, 93, 123, 121, 105, 140, 152, 191, 195, 205, 209, 168, 217, 239, 243, 237, 262, 295, 305, 332, 343, 341, 360, 358, 351, 369, 402, 400, 389, 413, 411, 423, 421, 431, 436, 441, 470, 483];
+ * @PONTOS-DE-PARADA = ;
+ * @SIMBOLOS-INSPECIONADOS = ;
+ * @FILTRO-ARVORE-TIPOS-DE-DADO = inteiro, real, logico, cadeia, caracter, vazio;
+ * @FILTRO-ARVORE-TIPOS-DE-SIMBOLO = variavel, vetor, matriz, funcao;
  */

--- a/ide/src/main/assets/exemplos/bibliotecas/graficos/senoides.por
+++ b/ide/src/main/assets/exemplos/bibliotecas/graficos/senoides.por
@@ -97,7 +97,7 @@ programa
 		
 		
 		para(real i=0.0; i<361.0; i+=0.5){
-			bolinha = u.sorteia(10,16)
+			bolinha = sorteia(10,16)
 			bolinha= 32*(iterador/360.0)+1
 			g.definir_cor(cor)
 			g.desenhar_elipse(base_x+m.seno(i*x)*espaco-bolinha/2, base_y+m.cosseno(i*y)*espaco-bolinha/2, bolinha, bolinha, verdadeiro)
@@ -124,25 +124,25 @@ programa
 			y++
 		}
 		se(t.tecla_pressionada(t.TECLA_C)){
-			cor_base = u.sorteia(-16777216,-1)
+			cor_base = sorteia(-16777216,-1)
 		}
 		se(t.tecla_pressionada(t.TECLA_D)){
-			cor_base = cores[u.sorteia(0,3)]
+			cor_base = cores[sorteia(0,3)]
 		}
 		se(t.tecla_pressionada(t.TECLA_A)){
 			auto_play = nao auto_play
 		}
 		se((u.tempo_decorrido()-tempo_i>tempo_a e auto_play) ou t.tecla_pressionada(t.TECLA_ESPACO)){
-			prob = u.sorteia(0, 100)
+			prob = sorteia(0, 100)
 			se (prob%10<2){
-				x = u.sorteia(0, 360)
-				y = u.sorteia(0, 360)
+				x = sorteia(0, 360)
+				y = sorteia(0, 360)
 			}senao{
-				pos = u.sorteia(0, 20)
+				pos = sorteia(0, 20)
 				x = demos[pos][0]
 				y = demos[pos][1]
 			}
-			cor_base = cores[u.sorteia(0,3)]
+			cor_base = cores[sorteia(0,3)]
 			tempo_i = u.tempo_decorrido()				
 		}
 		enquanto(t.alguma_tecla_pressionada()){
@@ -166,8 +166,8 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 949; 
- * @DOBRAMENTO-CODIGO = [1, 48, 72, 85, 112, 152];
+ * @POSICAO-CURSOR = 3427; 
+ * @DOBRAMENTO-CODIGO = [1, 48, 72, 152];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;
  * @FILTRO-ARVORE-TIPOS-DE-DADO = inteiro, real, logico, cadeia, caracter, vazio;

--- a/ide/src/main/assets/exemplos/bibliotecas/graficos/solar.por
+++ b/ide/src/main/assets/exemplos/bibliotecas/graficos/solar.por
@@ -126,7 +126,7 @@ programa
 			planetas[i][ORIGEM_Y]=yc
 			planetas[i][Y]=yc
 			planetas[i][DISTANCIA]= xp-xc
-			planetas[i][ANGULO]= u.sorteia(0, 360)
+			planetas[i][ANGULO]= sorteia(0, 360)
 			planetas[i][ANGULO_INC]= speed/tp.cadeia_para_real(inc)
 			planetas[i][COR]=g.criar_cor(tp.cadeia_para_inteiro(r,10), tp.cadeia_para_inteiro(g,10), tp.cadeia_para_inteiro(b,10))
 
@@ -187,9 +187,9 @@ programa
 		inteiro opacidade = 0
 		g.definir_cor(cor_branco)
 		para(inteiro i=0; i< estrelas; i++){
-			x= u.sorteia(0, w)
-			y = u.sorteia(0, h)
-			opacidade = u.sorteia(0, 255)
+			x= sorteia(0, w)
+			y = sorteia(0, h)
+			opacidade = sorteia(0, 255)
 			g.definir_opacidade(opacidade)
 			g.desenhar_elipse(x, y, tamanho_estrela, tamanho_estrela, verdadeiro)
 		}
@@ -217,8 +217,8 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 1024; 
- * @DOBRAMENTO-CODIGO = [1, 81, 90, 157, 166, 180, 198];
+ * @POSICAO-CURSOR = 4694; 
+ * @DOBRAMENTO-CODIGO = [1, 81, 157, 166, 198];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;
  * @FILTRO-ARVORE-TIPOS-DE-DADO = inteiro, real, logico, cadeia, caracter, vazio;

--- a/ide/src/main/assets/exemplos/bibliotecas/graficos/sphere.por
+++ b/ide/src/main/assets/exemplos/bibliotecas/graficos/sphere.por
@@ -247,7 +247,7 @@ programa
 			fps = frames
 			tempo_inicio_fps = u.tempo_decorrido() - (tempo_fps - 1000)
 			frames = 0
-			//cor = u.sorteia(0,16000000)			
+			//cor = sorteia(0,16000000)			
 		}
 	}
 
@@ -404,7 +404,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 6770; 
+ * @POSICAO-CURSOR = 8; 
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = {z_index, 33, 6, 7};
  * @FILTRO-ARVORE-TIPOS-DE-DADO = inteiro, real, logico, cadeia, caracter, vazio;

--- a/ide/src/main/assets/exemplos/bibliotecas/internet/robos.por
+++ b/ide/src/main/assets/exemplos/bibliotecas/internet/robos.por
@@ -24,10 +24,10 @@ programa
 		se(img != -1){
 			g.liberar_imagem(img)
 		}
-		chars = u.sorteia(3,10)
+		chars = sorteia(3,10)
 		hash = ""
 		para(inteiro i = 0 ; i < chars ; i++){
-			temp = u.sorteia(0, 23)
+			temp = sorteia(0, 23)
 			hash = hash + tx.obter_caracter(letras, temp)
 		}
 		
@@ -63,7 +63,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 8; 
+ * @POSICAO-CURSOR = 0; 
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;
  * @FILTRO-ARVORE-TIPOS-DE-DADO = inteiro, real, logico, cadeia, caracter, vazio;

--- a/ide/src/main/assets/exemplos/bibliotecas/util/sorteio.por
+++ b/ide/src/main/assets/exemplos/bibliotecas/util/sorteio.por
@@ -25,11 +25,9 @@
  * 	
  * Data: 18/07/2014
  */
- 
+
 programa
 {
-	inclua biblioteca Util --> u
-	
 	funcao inicio()
 	{
 		inteiro valor_inicial
@@ -50,7 +48,7 @@ programa
 		{
 			// Sorteia um número entre os valores informados, incluindo
 			// o próprio valor inicial e final
-			valor_sorteado = u.sorteia(valor_inicial, valor_final)
+			valor_sorteado = sorteia(valor_inicial, valor_final)
 			
 			escreva("\nSorteio nº ", i, ": ", valor_sorteado)
 		}
@@ -64,7 +62,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 970; 
+ * @POSICAO-CURSOR = 928; 
  * @DOBRAMENTO-CODIGO = [1];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;

--- a/ide/src/main/assets/exemplos/desvios_condicionais/numeros_iguais.por
+++ b/ide/src/main/assets/exemplos/desvios_condicionais/numeros_iguais.por
@@ -28,8 +28,6 @@
 
 programa
 {
-	inclua biblioteca Util --> util
-	
 	funcao inicio()
 	{
 		inteiro num_digitado, num_sorteado
@@ -37,7 +35,7 @@ programa
 		escreva("Informe um número de 0 a 6: ")
 		leia(num_digitado)
 
-		num_sorteado = util.sorteia(0, 6)
+		num_sorteado = sorteia(0, 6)
 
 		se (num_digitado >= 0 e num_digitado <= 6)
 		{
@@ -65,7 +63,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 991; 
+ * @POSICAO-CURSOR = 897; 
  * @DOBRAMENTO-CODIGO = [1];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;

--- a/ide/src/main/assets/exemplos/jogos/arkanoid.por
+++ b/ide/src/main/assets/exemplos/jogos/arkanoid.por
@@ -460,7 +460,7 @@ programa
 		centralizar_bolinha_no_bastao()
 
 		direcao_bolinha_vertical = ACIMA
-		direcao_bolinha_horizontal = u.sorteia(ESQUERDA, DIREITA)
+		direcao_bolinha_horizontal = sorteia(ESQUERDA, DIREITA)
 
 		velocidade_bolinha_vertical = VELOCIDADE_INICIAL_BOLINHA
 		velocidade_bolinha_horizontal = VELOCIDADE_INICIAL_BOLINHA
@@ -501,7 +501,7 @@ programa
 		inteiro x_minimo = borda_esquerda_tela()
 		inteiro x_maximo = borda_direita_tela() - largura_bastao
 		
-		x_bastao = tp.inteiro_para_real(u.sorteia(x_minimo, x_maximo))
+		x_bastao = tp.inteiro_para_real(sorteia(x_minimo, x_maximo))
 	}
 
 	funcao finalizar()

--- a/ide/src/main/assets/exemplos/jogos/colisoes/ex6_colisao_todos.por
+++ b/ide/src/main/assets/exemplos/jogos/colisoes/ex6_colisao_todos.por
@@ -171,7 +171,7 @@ programa
 		
 		enquanto (velocidade == 0)
 		{
-			velocidade = u.sorteia(-VELOCIDADE_MAXIMA, VELOCIDADE_MAXIMA)
+			velocidade = sorteia(-VELOCIDADE_MAXIMA, VELOCIDADE_MAXIMA)
 		}
 		
 		retorne velocidade

--- a/ide/src/main/assets/exemplos/jogos/corrida.por
+++ b/ide/src/main/assets/exemplos/jogos/corrida.por
@@ -824,7 +824,7 @@ programa
 		real y = 0.0
 		real x = sortear_posicao_faixa(12)
 
-		y = maior_distancia - u.sorteia(MENOR_DISTANCIA_GALOES, MAIOR_DISTANCIA_GALOES)
+		y = maior_distancia - sorteia(MENOR_DISTANCIA_GALOES, MAIOR_DISTANCIA_GALOES)
 		y = m.menor_numero(y, -(altura * 2.0))
 		
 		galoes[indice][_X] = x
@@ -872,7 +872,7 @@ programa
 		real y = 0.0
 		real x = sortear_posicao_faixa(12)
 		 
-		 y = maior_distancia - u.sorteia(MENOR_DISTANCIA_REPAROS, MAIOR_DISTANCIA_REPAROS)
+		 y = maior_distancia - sorteia(MENOR_DISTANCIA_REPAROS, MAIOR_DISTANCIA_REPAROS)
 		 y = m.menor_numero(y, -(altura * 2.0))
 		
 		pontos_reparo[indice][_X] = x
@@ -887,7 +887,7 @@ programa
 	funcao real sortear_posicao_faixa(inteiro numero_faixas)
 	{
 		inteiro largura = largura_faixa(numero_faixas)
-		inteiro faixa = u.sorteia(0, numero_faixas - 1)
+		inteiro faixa = sorteia(0, numero_faixas - 1)
 
 		se (faixa < numero_faixas / 2)
 		{
@@ -901,7 +901,7 @@ programa
 
 	funcao sortear_posicao_veiculo(inteiro indice)
 	{		
-		inteiro indice_modelo = u.sorteia(0, u.numero_linhas(MODELOS_VEICULOS) - 1)
+		inteiro indice_modelo = sorteia(0, u.numero_linhas(MODELOS_VEICULOS) - 1)
 				
 		inteiro largura = MODELOS_VEICULOS[indice_modelo][_LARGURA]
 		inteiro altura = MODELOS_VEICULOS[indice_modelo][_ALTURA]
@@ -916,12 +916,12 @@ programa
 		real y = 0.0
 		real x = sortear_posicao_faixa(4)
 		
-		y = maior_distancia - u.sorteia(MENOR_DISTANCIA_VEICULOS, MAIOR_DISTANCIA_VEICULOS)
+		y = maior_distancia - sorteia(MENOR_DISTANCIA_VEICULOS, MAIOR_DISTANCIA_VEICULOS)
 		y = m.menor_numero(y, -(altura * 2.0))
 
 		inteiro velocidade_minima = tp.real_para_inteiro(VELOCIDADE_MINIMA_VEICULOS)
 		inteiro velocidade_maxima = tp.real_para_inteiro(VELOCIDADE_MAXIMA_VEICULOS)
-		inteiro velocidade = u.sorteia(velocidade_minima, velocidade_maxima)
+		inteiro velocidade = sorteia(velocidade_minima, velocidade_maxima)
 		
 		veiculos[indice][_VELOCIDADE] = tp.inteiro_para_real(velocidade)
 		veiculos[indice][_MODELO] = tp.inteiro_para_real(indice_modelo)
@@ -1314,12 +1314,12 @@ programa
 		{
 			inteiro velocidade_minima = tp.real_para_inteiro(VELOCIDADE_MINIMA_VEICULOS)
 			inteiro velocidade_maxima = tp.real_para_inteiro(VELOCIDADE_MAXIMA_VEICULOS)
-			inteiro velocidade = u.sorteia(velocidade_minima, velocidade_maxima)
+			inteiro velocidade = sorteia(velocidade_minima, velocidade_maxima)
 
 			veiculos[i][_X] = 0.0
 			veiculos[i][_Y] = 1500.0
 			veiculos[i][_VELOCIDADE] = tp.inteiro_para_real(velocidade)
-			veiculos[i][_MODELO] = tp.inteiro_para_real(u.sorteia(0, u.numero_linhas(MODELOS_VEICULOS) - 1))
+			veiculos[i][_MODELO] = tp.inteiro_para_real(sorteia(0, u.numero_linhas(MODELOS_VEICULOS) - 1))
 		}
 
 		para (inteiro i = 0; i < u.numero_linhas(veiculos); i++)

--- a/ide/src/main/assets/exemplos/jogos/moon_lander.por
+++ b/ide/src/main/assets/exemplos/jogos/moon_lander.por
@@ -376,7 +376,7 @@ programa
 		}
 		senao
 		{
-			inteiro probabilidade = u.sorteia(1, 100)
+			inteiro probabilidade = sorteia(1, 100)
 
 			/* 
 			 * Se o foguete estiver dentro da plataforma, move para um dos lados, com 50%
@@ -418,7 +418,7 @@ programa
 			inteligencia_artificial_decidiu_acelerar = verdadeiro
 			tempo_inicio_aceleracao = u.tempo_decorrido()
 
-			inteiro probabilidade = u.sorteia(1, 100)
+			inteiro probabilidade = sorteia(1, 100)
 
 			/* 
 			 * Cria uma probabilidade de 5% de o foguete acelerar por tempo demais e se perder 
@@ -427,11 +427,11 @@ programa
 			
 			se (probabilidade <= 5) 
 			{				
-				tempo_escolhido_aceleracao = u.sorteia(500, 1000)
+				tempo_escolhido_aceleracao = sorteia(500, 1000)
 			}
 			senao
 			{
-				tempo_escolhido_aceleracao = u.sorteia(150, 350)
+				tempo_escolhido_aceleracao = sorteia(150, 350)
 			}
 		}
 	}
@@ -1023,19 +1023,19 @@ programa
 	{
 		para (inteiro indice = 0; indice < u.numero_linhas(estrelas_cintilantes); indice++)
 		{
-			inteiro brilho_minimo = u.sorteia(32, 64)
-			inteiro brilho_maximo = u.sorteia(128, 255)
+			inteiro brilho_minimo = sorteia(32, 64)
+			inteiro brilho_maximo = sorteia(128, 255)
 
-			estrelas_cintilantes[indice][POSICAO_X] = u.sorteia(20, LARGURA_DA_TELA - 20)
-			estrelas_cintilantes[indice][POSICAO_Y] = u.sorteia(20, ALTURA_DA_TELA - altura_da_lua - 20)
-			estrelas_cintilantes[indice][TAMANHO_DA_ESTRELA] = u.sorteia(2, 4)
+			estrelas_cintilantes[indice][POSICAO_X] = sorteia(20, LARGURA_DA_TELA - 20)
+			estrelas_cintilantes[indice][POSICAO_Y] = sorteia(20, ALTURA_DA_TELA - altura_da_lua - 20)
+			estrelas_cintilantes[indice][TAMANHO_DA_ESTRELA] = sorteia(2, 4)
 			
 			estrelas_cintilantes[indice][BRILHO_MINIMO] = brilho_minimo
 			estrelas_cintilantes[indice][BRILHO_MAXIMO] = brilho_maximo
-			estrelas_cintilantes[indice][BRILHO_ATUAL] = u.sorteia(brilho_minimo, brilho_maximo)
+			estrelas_cintilantes[indice][BRILHO_ATUAL] = sorteia(brilho_minimo, brilho_maximo)
 
-			estrelas_cintilantes[indice][VELOCIDADE_DA_ANIMACAO] = u.sorteia(1, 4)
-			estrelas_cintilantes[indice][ESTADO_DA_ANIMACAO] = u.sorteia(AUMENTANDO_BRILHO, DIMINUINDO_BRILHO)
+			estrelas_cintilantes[indice][VELOCIDADE_DA_ANIMACAO] = sorteia(1, 4)
+			estrelas_cintilantes[indice][ESTADO_DA_ANIMACAO] = sorteia(AUMENTANDO_BRILHO, DIMINUINDO_BRILHO)
 		}
 	}
 
@@ -1232,7 +1232,7 @@ programa
 
 	funcao reiniciar_jogo()
 	{
-		x_do_foguete = u.sorteia(10, LARGURA_DA_TELA - largura_do_foguete - 10)
+		x_do_foguete = sorteia(10, LARGURA_DA_TELA - largura_do_foguete - 10)
 		y_do_foguete = 0
 		
 		reiniciar_variaveis_de_controle()

--- a/ide/src/main/assets/exemplos/jogos/pong.por
+++ b/ide/src/main/assets/exemplos/jogos/pong.por
@@ -89,8 +89,8 @@ programa
 		bolinha[ACELERACAO]=1
 		max_vel=passo+3
 		enquanto(bolinha[V_HORIZONTAL]==0 ou bolinha[V_VERTICAL]==0){
-			bolinha[V_HORIZONTAL]=u.sorteia(passo-2, passo)*u.sorteia(-1, 1)
-			bolinha[V_VERTICAL]=(max_vel-ma.valor_absoluto(bolinha[V_HORIZONTAL]))*u.sorteia(-1, 1)
+			bolinha[V_HORIZONTAL]=sorteia(passo-2, passo)*sorteia(-1, 1)
+			bolinha[V_VERTICAL]=(max_vel-ma.valor_absoluto(bolinha[V_HORIZONTAL]))*sorteia(-1, 1)
 		}		
 	}
 
@@ -509,7 +509,7 @@ programa
 		{
 			se(u.tempo_decorrido()-tempo_anterior_demo>250)
 			{
-				player_demo_aleatoriedade = u.sorteia(1,10)%3
+				player_demo_aleatoriedade = sorteia(1,10)%3
 				tempo_anterior_demo=u.tempo_decorrido()
 			}
 			se(player2[Y]+passo+player2[ALTURA]<campo[Y]+campo[ALTURA]-tamanho_tile e player_demo_aleatoriedade==0){

--- a/ide/src/main/assets/exemplos/jogos/serpente.por
+++ b/ide/src/main/assets/exemplos/jogos/serpente.por
@@ -1457,8 +1457,8 @@ programa
 
 	funcao atualizar_posicao_comida()
 	{
-		comida[LINHA]  = u.sorteia(0, LINHAS  - 1)
-		comida[COLUNA] = u.sorteia(0, COLUNAS - 1)
+		comida[LINHA]  = sorteia(0, LINHAS  - 1)
+		comida[COLUNA] = sorteia(0, COLUNAS - 1)
 
 		enquanto (local_comida_invalido())
 		{

--- a/ide/src/main/assets/exemplos/jogos/slide.por
+++ b/ide/src/main/assets/exemplos/jogos/slide.por
@@ -48,8 +48,8 @@ programa
 	funcao embaralhar(inteiro mat[][]) {
        para (inteiro i = TAMANHO_PRANCHA - 1; i > 0; i--) {
             para (inteiro j = TAMANHO_PRANCHA - 1; j > 0; j--) {
-                inteiro m = u.sorteia(0,TAMANHO_PRANCHA - 1)
-                inteiro n = u.sorteia(0,TAMANHO_PRANCHA - 1)
+                inteiro m = sorteia(0,TAMANHO_PRANCHA - 1)
+                inteiro n = sorteia(0,TAMANHO_PRANCHA - 1)
                 inteiro temp = mat[i][j]
                 mat[i][j] = mat[m][n]
                 mat[m][n] = temp

--- a/ide/src/main/assets/exemplos/jogos/slide/slide.por
+++ b/ide/src/main/assets/exemplos/jogos/slide/slide.por
@@ -48,8 +48,8 @@ programa
 	funcao embaralhar(inteiro mat[][]) {
        para (inteiro i = TAMANHO_PRANCHA - 1; i > 0; i--) {
             para (inteiro j = TAMANHO_PRANCHA - 1; j > 0; j--) {
-                inteiro m = u.sorteia(0,TAMANHO_PRANCHA - 1)
-                inteiro n = u.sorteia(0,TAMANHO_PRANCHA - 1)
+                inteiro m = sorteia(0,TAMANHO_PRANCHA - 1)
+                inteiro n = sorteia(0,TAMANHO_PRANCHA - 1)
                 inteiro temp = mat[i][j]
                 mat[i][j] = mat[m][n]
                 mat[m][n] = temp

--- a/ide/src/main/assets/exemplos/subrotinas/parametros_referencia.por
+++ b/ide/src/main/assets/exemplos/subrotinas/parametros_referencia.por
@@ -42,9 +42,7 @@
  */
  
 programa
-{
-	inclua biblioteca Util --> util
-	
+{	
 	funcao inicio()
 	{
 		inteiro vet = 0 // Declara uma variável
@@ -64,7 +62,7 @@ programa
 	// passada por referência
 	funcao preenche (inteiro &v) 
 	{
-		v = util.sorteia (1, 100)
+		v = sorteia (1, 100)
 	}
 
 	// Exibe o valor contido na variavel. Neste caso, a variavel é 
@@ -84,7 +82,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 1909; 
+ * @POSICAO-CURSOR = 1810; 
  * @DOBRAMENTO-CODIGO = [1];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;

--- a/ide/src/main/assets/exemplos/subrotinas/vetores_parametro.por
+++ b/ide/src/main/assets/exemplos/subrotinas/vetores_parametro.por
@@ -42,9 +42,7 @@
  */
  
 programa
-{
-	inclua biblioteca Util --> util
-	
+{	
 	funcao inicio()
 	{
 		inteiro vet [10] // Declara um vetor com 10 posições
@@ -69,7 +67,7 @@ programa
 	{
 		para (inteiro i = 0; i < 10; i++)
 		{
-			v[i] = util.sorteia (1, 100)			
+			v[i] = sorteia (1, 100)			
 		}
 	}
 	
@@ -110,7 +108,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 1922; 
+ * @POSICAO-CURSOR = 1810; 
  * @DOBRAMENTO-CODIGO = [1];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;

--- a/ide/src/main/assets/exemplos/vetores_matrizes/exibe_matriz.por
+++ b/ide/src/main/assets/exemplos/vetores_matrizes/exibe_matriz.por
@@ -41,7 +41,7 @@ programa
 		{
 			para (inteiro coluna = 0; coluna < TAMANHO; coluna++)
 			{
-				matriz[linha][coluna] = u.sorteia(1, 9) // Atribui um valor aleatório à posição da matriz
+				matriz[linha][coluna] = sorteia(1, 9) // Atribui um valor aleatório à posição da matriz
 				
 				escreva("[", matriz[linha][coluna], "]") // Exibe o valor contido na posição da matriz
 			}
@@ -56,7 +56,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 923; 
+ * @POSICAO-CURSOR = 787; 
  * @DOBRAMENTO-CODIGO = [1];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;

--- a/ide/src/main/assets/exemplos/vetores_matrizes/preenche_vetor.por
+++ b/ide/src/main/assets/exemplos/vetores_matrizes/preenche_vetor.por
@@ -30,8 +30,6 @@
 
 programa
 {
-	inclua biblioteca Util --> util
-	
 	funcao inicio() 
 	{
 		inteiro vetor[10]
@@ -39,7 +37,7 @@ programa
 		// preenche o vetor
 		para (inteiro posicao = 0; posicao < 10; posicao++)
 		{
-			vetor[posicao] = util.sorteia(1, 100) // Sorteia um número e atribui à posição do vetor
+			vetor[posicao] = sorteia(1, 100) // Sorteia um número e atribui à posição do vetor
 		}
 
 		// Exibe o vetor na ordem original
@@ -65,7 +63,7 @@ programa
  * Esta seção do arquivo guarda informações do Portugol Studio.
  * Você pode apagá-la se estiver utilizando outro editor.
  * 
- * @POSICAO-CURSOR = 1015; 
+ * @POSICAO-CURSOR = 937; 
  * @DOBRAMENTO-CODIGO = [1];
  * @PONTOS-DE-PARADA = ;
  * @SIMBOLOS-INSPECIONADOS = ;


### PR DESCRIPTION
 - Removendo a função sorteia da biblioteca;
- Refatorando exemplos para usarem direto da linguagem.

Arquivos antigos com 'u.sorteia' acusarão erro e alguns usuários podem não perceber o motivo.
Devemos mesmo remover ou manter em ambos os lugares por questão de compatibilidade? 
(#606)