### PR TITLE
:bug: corrigindo erros sintatico do senao (fix #810)

### DIFF
--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/GeradorASA.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/GeradorASA.java
@@ -680,7 +680,7 @@ public class GeradorASA {
             if (ctx.SENAO() != null) {
                 if(ctx.SENAO() instanceof ErrorNodeImpl)
                 {
-                    //throw new ErroComandoEsperado(10, 50);
+                    throw new RecognitionException("ERROSENAO", parser, null, ctx);
                 }
                 se.setBlocosFalsos(getBlocos(ctx.listaComandos(1)));
             }

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/GeradorASA.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/GeradorASA.java
@@ -5,10 +5,14 @@ import br.univali.portugol.nucleo.analise.sintatica.antlr4.PortugolBaseVisitor;
 import br.univali.portugol.nucleo.analise.sintatica.antlr4.PortugolParser;
 import br.univali.portugol.nucleo.asa.*;
 import br.univali.portugol.nucleo.analise.sintatica.antlr4.PortugolParser.*;
+import br.univali.portugol.nucleo.analise.sintatica.erros.ErroComandoEsperado;
 import java.util.ArrayList;
 import java.util.List;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ErrorNodeImpl;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 public class GeradorASA {
@@ -672,8 +676,12 @@ public class GeradorASA {
             NoSe se = new NoSe((NoExpressao)ctx.expressao().accept(this));
             
             se.setBlocosVerdadeiros(getBlocos(ctx.listaComandos(0)));
-            
+                        
             if (ctx.SENAO() != null) {
+                if(ctx.SENAO() instanceof ErrorNodeImpl)
+                {
+                    //throw new ErroComandoEsperado(10, 50);
+                }
                 se.setBlocosFalsos(getBlocos(ctx.listaComandos(1)));
             }
             

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroComandoInesperado.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroComandoInesperado.java
@@ -15,7 +15,7 @@ public class ErroComandoInesperado extends ErroSintatico
     @Override
     protected String construirMensagem()
     {
-        return String.format("O comando '%s' não era esperada neste local, remova-o para corrigir o problema", token);
+        return String.format("O comando '%s' não era esperado neste local, remova-o para corrigir o problema", token);
     }    
 
     public String getToken() {

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroComandoInesperado.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroComandoInesperado.java
@@ -1,0 +1,25 @@
+package br.univali.portugol.nucleo.analise.sintatica.erros;
+
+import br.univali.portugol.nucleo.mensagens.ErroSintatico;
+
+public class ErroComandoInesperado extends ErroSintatico
+{
+    private String token;
+    
+    public ErroComandoInesperado(int linha, int coluna, String token)
+    {
+        super(linha, coluna,"ErroSintatico.ErroExpressaoInesperada");
+        this.token = token;
+    }
+    
+    @Override
+    protected String construirMensagem()
+    {
+        return String.format("O comando '%s' não era esperada neste local, remova-o para corrigir o problema", token);
+    }    
+
+    public String getToken() {
+        return token;
+    }
+    
+}

--- a/ide/src/main/java/br/univali/ps/ui/utils/FabricaDeFileChooser.java
+++ b/ide/src/main/java/br/univali/ps/ui/utils/FabricaDeFileChooser.java
@@ -54,7 +54,7 @@ public class FabricaDeFileChooser {
                                 return;
                             }
                         }
-                        if((selectedFile != null) && (selectedFile.getName().matches(".*[><\"/|?\\*].*") || FileHandle.isFilenameValid(selectedFile.getPath())))
+                        if((selectedFile != null) && (selectedFile.getName().matches(".*[><\"/|?\\*].*") || !FileHandle.isFilenameValid(selectedFile.getPath())))
                         {
                             QuestionDialog.getInstance().showMessage("O nome do arquivo não é permitido. \n O nome não pode conter os caracteres \n > < : \" / | ? *,", JOptionPane.WARNING_MESSAGE);
                             return;


### PR DESCRIPTION
O seguinte gera o erro da issue #810 
![image](https://user-images.githubusercontent.com/8836540/92340752-f8019980-f091-11ea-9582-0c822cbb13fe.png)

Ao tentar localizar o erro, foi percebido que o problema não é identificado pelo PortugolParser como um erro sintatico. Portanto ele tenta executar normalmente gerando um erro no gerador de ASA que não consegue encontrar os blocos do senao.
Ao mesmo tempo, foi percebido que o TerminalNode do SENAO vem instanciado na classe ErrorNodeImpl, quando analisado pelo geradorASA. Foi então suposto que ele identifica sim o problema, mas no Parser passa despercebido.
Por isso, foi feito uma captura dessa instancia no gerador e retornado como um RecognitionException, pois é o unico tipo que o gerador retorna. Porém o construtor dessa exceção não permite setar os tokens esperados, gerando um erro no tradutor de erros em tokens.
Como ele permite setar uma mensagem, foi utilizado uma para identificar no tradutor o novo tipo de erro e de lá conseguir enviar um erro padrão do sistema.

Essa solução resolve a exceção que é jogada para o usuário, entretanto não resolve o problema do PortugolParser ignorar o erro sintático. Esse erro pode também estar relacionado com as issues #834 e #759 em que o Portugol também ignora sintaticamente a utilização do senao de forma errada.
