### PR TITLE
:bug: corrigindo pare fora de loop switch (fix #761)

### DIFF
--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/AnalisadorSintatico.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/AnalisadorSintatico.java
@@ -6,6 +6,7 @@ import br.univali.portugol.nucleo.analise.sintatica.antlr4.PortugolLexer;
 import br.univali.portugol.nucleo.analise.sintatica.antlr4.PortugolParser;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroExpressaoInesperada;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroInteiroForaDoIntervalo;
+import br.univali.portugol.nucleo.analise.sintatica.erros.ErroPareForaDeLoopOuSwitch;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroTokenFaltando;
 import br.univali.portugol.nucleo.analise.sintatica.tradutores.TradutorMismatchedTokenException;
 import br.univali.portugol.nucleo.asa.ASA;
@@ -190,12 +191,21 @@ public final class AnalisadorSintatico
             return asa;
         }
         catch (RecognitionException excecao) {
-            tratarErroParsing(excecao, excecao.getLocalizedMessage());
+            if(excecao.getMessage().equals("Pare fora de escopo"))
+                tratarErroPare(excecao);
+            else
+                tratarErroParsing(excecao, excecao.getLocalizedMessage());
         }
         catch(ParseCancellationException e) {
             System.out.println(e);
         }
         return null;
+    }
+    
+    private void tratarErroPare(RecognitionException excecao)
+    {
+        Token pare = ((PortugolParser.PareContext) excecao.getCtx()).PARE().getSymbol();
+        notificarErroSintatico(new ErroPareForaDeLoopOuSwitch(pare.getLine(), pare.getCharPositionInLine(), pare.getText()));
     }
 
     private void verificarCaracteresAposEscopoPrograma(String codigoFonte) {

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/GeradorASA.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/GeradorASA.java
@@ -275,7 +275,7 @@ public class GeradorASA {
         
         private boolean estaDentroDeUmLoop(RuleContext ctx)
         {
-            if(ctx instanceof ParaContext || ctx instanceof EnquantoContext || ctx instanceof FacaEnquantoContext)
+            if(ctx instanceof ParaContext || ctx instanceof EnquantoContext || ctx instanceof FacaEnquantoContext || ctx instanceof EscolhaContext)
             {
                 return true;
             }

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroPareForaDeLoopOuSwitch.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroPareForaDeLoopOuSwitch.java
@@ -1,0 +1,25 @@
+package br.univali.portugol.nucleo.analise.sintatica.erros;
+
+import br.univali.portugol.nucleo.mensagens.ErroSintatico;
+
+public class ErroPareForaDeLoopOuSwitch extends ErroSintatico
+{
+    private String token;
+    
+    public ErroPareForaDeLoopOuSwitch(int linha, int coluna, String token)
+    {
+        super(linha, coluna,"ErroSintatico.ErroExpressaoInesperada");
+        this.token = token;
+    }
+    
+    @Override
+    protected String construirMensagem()
+    {
+        return String.format("O comando '%s' apenas pode ser utilizado dentro de Loops (como para, enquanto e faça enquanto) ou dentro de um escolha-caso", token);
+    }    
+
+    public String getToken() {
+        return token;
+    }
+    
+}

--- a/core/src/test/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErrosSintaticosTest.java
+++ b/core/src/test/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErrosSintaticosTest.java
@@ -87,6 +87,25 @@ public class ErrosSintaticosTest {
     }
     
     @Test
+    public void testPareForaDeLoop() throws Exception {
+         String codigoFonte
+                = " programa {                                                  "
+                + "    funcao inicio(){                                         "
+                + "             pare                                            "
+                + "       }                                                     "
+                + "    }                                                        "
+                + " }                                                           ";
+
+        AnalisadorAlgoritmo analisador = new AnalisadorAlgoritmo();
+        ResultadoAnalise analise = analisador.analisar(codigoFonte);
+                
+        Assert.assertEquals(1, analise.getErrosSintaticos().size());
+        
+        ErroSintatico erro = analise.getErrosSintaticos().get(0);
+        Assert.assertTrue(erro instanceof ErroPareForaDeLoopOuSwitch);
+    }
+    
+    @Test
     public void testParametrosNaoTipados() throws Exception {
          String codigoFonte
                 = " programa {                                                  "


### PR DESCRIPTION
# Resumo
Essa issue (#761) foi resolvida jogando uma exceção de dentro do visitor.
Não é a melhor maneira de resolver, mas foi a mais fácil comparada à correta.

# Maneira correta

O problema do `pare` passa pelo fato de que ele pode ser apenas utilizado dentro de loops ou switchs, não importando o escopo local.
Isso deve ser resolvido no ANTLR, entretanto o nosso utiliza uma `listaDeComandos` que possui o `comando` contendo o `pare`. Essa lista é utilizada tanto nos loops, quanto no `se-senao`.
O problema começa quando `se` e `senao` só podem receber o comando `pare` se eles estiverem dentro de um loop. Até onde eu vi, com a atual gramática teria que se criar uma `se-senao` exclusivo para quando estão dentro do loop.
Isso escalaria em muitas modificações no visitor e códigos repetidos.
Se souberem de alguma outra forma de resolver estamos aí.

# Resultado
![image](https://user-images.githubusercontent.com/8836540/99160428-05588700-26c6-11eb-9bc0-11943f273a17.png)
