### PR TITLE
:bug: capturando erros de escopo

### DIFF
--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroExpressaoForaEscopoFuncao.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroExpressaoForaEscopoFuncao.java
@@ -2,20 +2,20 @@ package br.univali.portugol.nucleo.analise.sintatica.erros;
 
 import br.univali.portugol.nucleo.mensagens.ErroSintatico;
 
-public class ErroExpressaoInesperada extends ErroSintatico
+public class ErroExpressaoForaEscopoFuncao extends ErroSintatico
 {
     private String token;
     
-    public ErroExpressaoInesperada(int linha, int coluna, String token)
+    public ErroExpressaoForaEscopoFuncao(int linha, int coluna, String token)
     {
-        super(linha, coluna,"ErroSintatico.ErroExpressaoInesperada");
+        super(linha, coluna,"ErroSintatico.ErroExpressaoForaEscopoFuncao");
         this.token = token;
     }
     
     @Override
     protected String construirMensagem()
     {
-        return String.format("A expressão '%s' não era esperada neste local, remova a expressão para corrigir o problema", token);
+        return String.format("A expressão '%s' está fora de um escopo de função e nunca será chamada. Adicione ela a uma função ou remova-a.", token);
     }    
 
     public String getToken() {

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroExpressaoForaEscopoFuncao.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/erros/ErroExpressaoForaEscopoFuncao.java
@@ -1,0 +1,25 @@
+package br.univali.portugol.nucleo.analise.sintatica.erros;
+
+import br.univali.portugol.nucleo.mensagens.ErroSintatico;
+
+public class ErroExpressaoInesperada extends ErroSintatico
+{
+    private String token;
+    
+    public ErroExpressaoInesperada(int linha, int coluna, String token)
+    {
+        super(linha, coluna,"ErroSintatico.ErroExpressaoInesperada");
+        this.token = token;
+    }
+    
+    @Override
+    protected String construirMensagem()
+    {
+        return String.format("A expressão '%s' não era esperada neste local, remova a expressão para corrigir o problema", token);
+    }    
+
+    public String getToken() {
+        return token;
+    }
+    
+}

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/tradutores/TradutorMismatchedTokenException.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/tradutores/TradutorMismatchedTokenException.java
@@ -7,6 +7,7 @@ import br.univali.portugol.nucleo.analise.sintatica.erros.ErroComandoEsperado;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroEscapeUnico;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroEscopo;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroExpressaoEsperada;
+import br.univali.portugol.nucleo.analise.sintatica.erros.ErroExpressaoForaEscopoFuncao;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroExpressaoIncompleta;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroExpressaoInesperada;
 import br.univali.portugol.nucleo.analise.sintatica.erros.ErroExpressoesForaEscopoPrograma;
@@ -83,6 +84,11 @@ public final class TradutorMismatchedTokenException
             if(token.equals("senao"))
             {
                return new ErroSenaoInesperado(linha, coluna, token);
+            }
+            
+            if(contextoAtual.equals("arquivo"))
+            {
+                return new ErroExpressaoForaEscopoFuncao(linha, coluna, token);
             }
             
             if(contextoAtual.equals("expressao") && contextos.getContextoPai().equals("declaracaoVariavel"))


### PR DESCRIPTION
Captura erros de expressões fora escopos de função. Como o da #883 .
Anteriormente retornava apenas que a variavel não tinha sido inicializada.
Agora com o #871 , ele consegue capturar como um token indesejavel e é possível dar uma melhor erro.