### PR TITLE
removendo_erro_fora_de_escopo

### DIFF
--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/tradutores/TradutorMismatchedTokenException.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/tradutores/TradutorMismatchedTokenException.java
@@ -86,10 +86,10 @@ public final class TradutorMismatchedTokenException
                return new ErroSenaoInesperado(linha, coluna, token);
             }
             
-            if(contextoAtual.equals("arquivo"))
-            {
-                return new ErroExpressaoForaEscopoFuncao(linha, coluna, token);
-            }
+//            if(contextoAtual.equals("arquivo"))
+//            {
+//                return new ErroExpressaoForaEscopoFuncao(linha, coluna, token);
+//            }
             
             if(contextoAtual.equals("expressao") && contextos.getContextoPai().equals("declaracaoVariavel"))
             {
@@ -101,7 +101,7 @@ public final class TradutorMismatchedTokenException
                 return new ErroParaEsperaCondicao(linha, coluna);
             }
             
-            if(contextoAtual.equals("parametroFuncao"))
+            if(contextoAtual.equals("parametroFuncao") && tokensEsperados.contains("FECHA_PARENTESES"))
             {
                 return new ErroParametrosNaoTipados(linha, coluna, token);
             }

--- a/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/tradutores/TradutorMismatchedTokenException.java
+++ b/core/src/main/java/br/univali/portugol/nucleo/analise/sintatica/tradutores/TradutorMismatchedTokenException.java
@@ -84,7 +84,7 @@ public final class TradutorMismatchedTokenException
             if(token.equals("senao"))
             {
                return new ErroSenaoInesperado(linha, coluna, token);
-            }
+            } 
             
 //            if(contextoAtual.equals("arquivo"))
 //            {


### PR DESCRIPTION
# Resumo
Na versão atual do master com o pull #884 aconteceu o problema de um dos testes falhar mas não ser pego pelo travis. (Por alguma razão estava desativado).
Fui verificar o problema e o portugol na versão do master, considera quealquer texto fora de um escopo, como um possível texto que pode ser colocado no escopo. ou seja, para ele um `escreva` fora de escopo tem a mesma validade que um `oijoij` jogado no meio do arquivo.
Nesse pull, o erro do escopo é removido, mantendo apenas o erro de "expressão inesperada". Que pede apenas que o texto seja removido.

# Problema
Com o erro de fora de escopo, ele vai tratar as seguintes situações com o mesmo erro:
situação 1
![image](https://user-images.githubusercontent.com/8836540/99720341-63051e80-2a8c-11eb-8ee4-55a0ad320d20.png)
situação 2
![image](https://user-images.githubusercontent.com/8836540/99720403-76b08500-2a8c-11eb-9024-6816b1c4c6cd.png)
situacao 3
![image](https://user-images.githubusercontent.com/8836540/99720499-98117100-2a8c-11eb-93ec-4f172616a462.png)

Sem ela, as três virariam esse erro:

![image](https://user-images.githubusercontent.com/8836540/99721441-ff7bf080-2a8d-11eb-83c6-5de4741c716f.png)


# Discussão
Bom, existe a possibilidade de manter do jeito que está e só alterar o caso de teste. Particularmente eu preferiria deixar só o Erro de expressão inesperada, que acho que funcionaria para todos os casos.
É importante decidir isso pois o travis vai continuar falhando no master, por o teste estar errado.
Ou retornamos para a Expressão inesperada.
Ou tempos que alterar o teste para pegar erros de fora de escopo.