### PR TITLE
:memo: Adicionando exemplo com carácter na ajuda

### DIFF
--- a/ide/src/main/assets/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo1.por
+++ b/ide/src/main/assets/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo1.por
@@ -18,18 +18,6 @@ escolha(numero)
 		//Instruções caso nenhum dos casos anteriores não seja verdadeiro
 }
 
-cadeia texto
-leia(texto)
-escolha(texto)
-{
-	caso "sim":
-		//Instruções caso o texto for igual a "sim"
-	pare
-
-	caso "nao":
-		//Instruções caso o texto for igual a "nao"
-}
-
 caracter simbolo
 leia(simbolo)
 escolha(simbolo)

--- a/ide/src/main/assets/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo1.por
+++ b/ide/src/main/assets/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo1.por
@@ -3,19 +3,19 @@ leia(numero)
 escolha(numero)
 {
 	caso 1:
-		//Instruções caso o numero for igual a 1
+		//InstruÃ§Ãµes caso o numero for igual a 1
 	pare
 
 	caso 2:
-		//Instruções caso o numero for igual a 2
+		//InstruÃ§Ãµes caso o numero for igual a 2
 	pare
 	
 	caso 50:
-		//Instruções caso o numero for igual a 50
+		//InstruÃ§Ãµes caso o numero for igual a 50
 	pare
 	
 	caso contrario:
-		//Instruções caso nenhum dos casos anteriores não seja verdadeiro
+		//InstruÃ§Ãµes caso nenhum dos casos anteriores nÃ£o seja verdadeiro
 }
 
 cadeia texto
@@ -23,16 +23,32 @@ leia(texto)
 escolha(texto)
 {
 	caso "sim":
-		//Instruções caso o texto for igual a "sim"
+		//InstruÃ§Ãµes caso o texto for igual a "sim"
 	pare
 
 	caso "nao":
-		//Instruções caso o texto for igual a "nao"
+		//InstruÃ§Ãµes caso o texto for igual a "nao"
+}
+
+caracter simbolo
+leia(simbolo)
+escolha(simbolo)
+{
+	caso 's':
+		//InstruÃ§Ãµes caso o caracter for igual a 's'
+	pare
+
+	caso '[':
+		//InstruÃ§Ãµes caso o caracter for igual a '['
+	pare
+
+	caso '*':
+		//InstruÃ§Ãµes caso o caracter for igual a '*'
 }
 /* $$$ Portugol Studio $$$ 
  * 
- * Esta seção do arquivo guarda informações do Portugol Studio.
- * Você pode apagá-la se estiver utilizando outro editor.
+ * Esta seÃ§Ã£o do arquivo guarda informaÃ§Ãµes do Portugol Studio.
+ * VocÃª pode apagÃ¡-la se estiver utilizando outro editor.
  * 
  * @POSICAO-CURSOR = 458; 
  */


### PR DESCRIPTION
Alguns estudantes estavam tentando fazer um escolha-caso de caracter usando aspas duplas, depois falavam que na documentação estava assim